### PR TITLE
Wrap re-exports into namespaces

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,5 +39,6 @@
     "react": {
       "version": "detect"
     }
-  }
+  },
+  "ignorePatterns": [ "dist/*" ]
 }

--- a/package.json
+++ b/package.json
@@ -12,15 +12,15 @@
     "node": ">=10"
   },
   "scripts": {
+    "prebuild": "run-s test",
     "build": "microbundle-crl --no-compress --format modern,cjs --css-modules false",
     "start": "echo Consider running: yarn sync-to-facet ; echo ; microbundle-crl watch --no-compress --format modern,cjs --css-modules false",
     "sync-to-facet": "FACET_ROOT=../facet ./scripts/sync-dist.sh",
-    "Xprepare": "run-s build",
     "prepare": "install-peers",
-    "test": "run-s test:unit test:lint test:build",
-    "test:build": "run-s build",
+    "test": "run-s test:circular test:lint",
     "test:lint": "eslint .",
     "test:unit": "cross-env CI=1 react-scripts test --env=jsdom",
+    "test:circular": "dpdm --warning false --tree false src/index.ts | grep 'no circular dependency were found'",
     "test:watch": "react-scripts test --env=jsdom",
     "lint": "eslint src/**/*.{tsx,ts} --color --fix",
     "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,json,md,scss,yaml,yml}'"
@@ -94,6 +94,7 @@
     "cross-env": "^7.0.2",
     "cross-spawn": "^7.0.1",
     "docz": "^2.1.1",
+    "dpdm": "^3.4.3",
     "eslint": "^6.8.0",
     "eslint-config-airbnb": "^18.0.1",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,7 +1,8 @@
 export * from './axiosClient';
+export * from './utils';
+
+export * from './clusters';
 export * from './events';
-export * from './useApi';
 export * from './versions';
 
-export * from './types';
-export * from './utils';
+export { default as useApi } from './useApi';

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,8 @@ import './hacks';
 
 export * from './components';
 
-export * from './api';
-export * from './config';
-export * from './selectors';
-export * from './store';
-export * from './types';
+export * as Api from './api';
+export * as Config from './config';
+export * as Selectors from './selectors';
+export * as Store from './store';
+// export * as Types from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2554,6 +2554,13 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
+"@types/fs-extra@^8.0.0":
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.1.tgz#1e49f22d09aa46e19b51c0b013cb63d0d923a068"
+  integrity sha512-TcUlBem321DFQzBNuz8p0CLLKp0VvF/XH9E4KHNmgwyp4E3AfgI5cjiIVZWlbfThBop2qxFIh4+LeY6hVWWZ2w==
+  dependencies:
+    "@types/node" "*"
+
 "@types/get-port@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@types/get-port/-/get-port-3.2.0.tgz#f9e0a11443cc21336470185eae3dfba4495d29bc"
@@ -5088,7 +5095,7 @@ cli-spinners@^1.0.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.3.1.tgz#002c1990912d0d59580c93bd36c056de99e4259a"
   integrity sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==
 
-cli-spinners@^2.0.0:
+cli-spinners@^2.0.0, cli-spinners@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.3.0.tgz#0632239a4b5aa4c958610142c34bb7a651fc8df5"
   integrity sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==
@@ -7037,6 +7044,22 @@ dotgitignore@2.1.0:
   dependencies:
     find-up "^3.0.0"
     minimatch "^3.0.4"
+
+dpdm@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/dpdm/-/dpdm-3.4.3.tgz#44a9fa9c6c39d164aa05f918968b94b170905fc9"
+  integrity sha512-F9GZbsh7KKxA3hJ35JQJVB3A/k9Mq7RRlZyrD2rPNFrvFUb36c18kwGPLEiyCyU+TxT35d+7USwhSy18s1L3XA==
+  dependencies:
+    "@types/fs-extra" "^8.0.0"
+    "@types/glob" "^7.1.1"
+    "@types/yargs" "^13.0.0"
+    chalk "^2.4.2"
+    fs-extra "^8.1.0"
+    glob "^7.1.4"
+    ora "^4.0.3"
+    tslib "^1.10.0"
+    typescript "^3.5.3"
+    yargs "^13.3.0"
 
 dtsgenerator@^1.2.0:
   version "1.2.0"
@@ -11025,6 +11048,11 @@ is-installed-globally@^0.1.0:
     global-dirs "^0.1.0"
     is-path-inside "^1.0.0"
 
+is-interactive@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
+  integrity sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==
+
 is-invalid-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-invalid-path/-/is-invalid-path-0.1.0.tgz#307a855b3cf1a938b44ea70d2c61106053714f34"
@@ -14044,6 +14072,20 @@ ora@^3.4.0:
     cli-spinners "^2.0.0"
     log-symbols "^2.2.0"
     strip-ansi "^5.2.0"
+    wcwidth "^1.0.1"
+
+ora@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-4.0.4.tgz#e8da697cc5b6a47266655bf68e0fb588d29a545d"
+  integrity sha512-77iGeVU1cIdRhgFzCK8aw1fbtT1B/iZAvWjS+l/o1x0RShMgxHUZaD2yDpWsNCPwXg9z1ZA78Kbdvr8kBmG/Ww==
+  dependencies:
+    chalk "^3.0.0"
+    cli-cursor "^3.1.0"
+    cli-spinners "^2.2.0"
+    is-interactive "^1.0.0"
+    log-symbols "^3.0.0"
+    mute-stream "0.0.8"
+    strip-ansi "^6.0.0"
     wcwidth "^1.0.1"
 
 original@>=0.0.5, original@^1.0.0:
@@ -19445,7 +19487,7 @@ typescript@3.5.3:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
   integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
-typescript@^3.8.3, typescript@^3.9.3:
+typescript@^3.5.3, typescript@^3.8.3, typescript@^3.9.3:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==


### PR DESCRIPTION
Components can be imported directly. The rest of code is wrapped into namespaces.

In addition, potential circular dependencies cause build failure.