### PR TITLE
Fix the cluster table header styling

### DIFF
--- a/src/components/ui/table/sortable.tsx
+++ b/src/components/ui/table/sortable.tsx
@@ -45,7 +45,6 @@ const sortable: ITransform = (label, extra: IExtra | undefined) => {
         isSortedBy={isSortedBy}
         sortDirection={isSortedBy ? sortBy?.direction : ''}
         onSort={sortClicked}
-        className="pf-c-button pf-m-plain"
         // eslint-disable-next-line
         // @ts-ignore
         type="button"


### PR DESCRIPTION
Given that I didn't test this locally and don't know React, I would be shocked if this is correct. Feel free to close and fix elsewhere. 🙂

This PR tries to remove two button-related classes on `.pf-c-table__button-content` that aren't needed, fixing the styling to go from this:

![image](https://user-images.githubusercontent.com/9122899/85344708-6df85a80-b4be-11ea-85c3-658563665c23.png)

To this:

![image](https://user-images.githubusercontent.com/9122899/85344695-6042d500-b4be-11ea-8078-a3397a79b4c4.png)