### PR TITLE
Remove footer alert padding

### DIFF
--- a/src/components/ui/AlertsSection/AlertsSection.css
+++ b/src/components/ui/AlertsSection/AlertsSection.css
@@ -1,6 +1,5 @@
 .pf-c-alert-group.alerts-section {
   position: absolute;
-  padding: var(--pf-c-page__main-section--PaddingTop);
   bottom: 0;
   width: 100%;
 }


### PR DESCRIPTION
Attempts to resolve [MGMT-1234](https://issues.redhat.com/browse/MGMT-1234) by removing the top padding (which doesn't seem to do anything?) defined in the custom CSS for `.pf-c-alert-group.alerts-section`. This allows the `ssh-keygen` command to be selected.

Feel free to close if this isn't the right approach. It seems like the entire div and this CSS could be removed with no effect on the alerts that appear in the footer.

Removes the green region here:

![image](https://user-images.githubusercontent.com/9122899/85347897-f29ba680-b4c7-11ea-9924-706621b9b23c.png)