### PR TITLE
Relabels Created At column heading to Discovered At

### DIFF
--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -52,7 +52,7 @@ const columns = [
   { title: 'Hostname', transforms: [sortable], cellFormatters: [expandable] },
   { title: 'Role', transforms: [sortable] },
   { title: 'Status', transforms: [sortable] },
-  { title: 'Created At', transforms: [sortable] },
+  { title: 'Discovered At', transforms: [sortable] },
   { title: 'CPU Cores', transforms: [sortable] }, // cores per machine (sockets x cores)
   { title: 'Memory', transforms: [sortable] },
   { title: 'Disk', transforms: [sortable] },


### PR DESCRIPTION
This PR attempts to rename the `Created At` column heading to `Discovered At`. The word "created" may match what's happening in the backend, but from the user's perspective these hosts are "Discovered" at a certain time, and "Discovering" is [the first status](https://docs.google.com/document/d/1jxNMTlotmJ0GFZ1GUEQ3hfOOVLzMT6mvY8Ufo5RdErY/edit#heading=h.gptlbp92g8lj) a user sees when the host appears in the table. WDYT @romfreiman @avishayt?

I see some references to `createdAt` in the code but don't want to break anything by renaming those too. 🙂 Feel free to close this PR and tweak it elsewhere if we generally agree with this proposed change.

![image](https://user-images.githubusercontent.com/9122899/85348850-d0efee80-b4ca-11ea-97a6-52b8496da940.png)