### PR TITLE
Tweak role selection text

### DIFF
--- a/src/components/ui/SimpleDropdown.tsx
+++ b/src/components/ui/SimpleDropdown.tsx
@@ -37,7 +37,7 @@ export const SimpleDropdown: React.FC<SimpleDropdownProps> = ({
         toggleIndicator={CaretDownIcon}
         isDisabled={isDisabled}
       >
-        {current || 'Please select'}
+        {current || 'Select a role'}
       </DropdownToggle>
     ),
     [setOpen, current, isDisabled],


### PR DESCRIPTION
A minor wording tweak to include the noun in the prompt similar to what we do if this were a PatternFly form field, like [this example](https://www.patternfly.org/v4/design-guidelines/usage-and-behavior/forms#validation-on-submission).

### Current

![image](https://user-images.githubusercontent.com/9122899/85358937-f0931100-b4e2-11ea-956b-47f9e02f0eff.png)

### New

![image](https://user-images.githubusercontent.com/9122899/85359226-ac544080-b4e3-11ea-86b9-44e741d8755f.png)