### PR TITLE
Add boot order instructions to ISO modal

### DIFF
--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -145,6 +145,12 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
                     Each host will need a valid IP address assigned by a DHCP server with DNS
                     records that fully resolve.
                   </Text>
+                  <Text component="p">
+                    The Discovery ISO should only be booted once per host. Either adjust the boot
+                    order in each host's BIOS to make it secondary after the first alpabetical disk,
+                    or select the ISO once manually. All other disks in the host will be wiped
+                    during the installation.
+                  </Text>
                 </TextContent>
                 <InputField
                   label="HTTP Proxy URL"


### PR DESCRIPTION
Adds three sentences to the ISO modal to clarify the boot order requirements that have been confusing folks. We can do better than this eventually, but this should help a little for now.

![image](https://user-images.githubusercontent.com/9122899/85362790-5be1e080-b4ed-11ea-9dd9-fa5d084ad94c.png)