### PR TITLE
Add ISO link to ISO download dialog

### DIFF
--- a/src/api/clusters.ts
+++ b/src/api/clusters.ts
@@ -40,7 +40,7 @@ export const createClusterDownloadsImage = (
   id: string,
   params: ImageCreateParams,
   axiosOptions: AxiosRequestConfig,
-): AxiosPromise<void> => client.post(`/clusters/${id}/downloads/image`, params, axiosOptions);
+): AxiosPromise<Cluster> => client.post(`/clusters/${id}/downloads/image`, params, axiosOptions);
 
 // TODO(jtomasek): make the API_ROOT configurable so this can be used in cloud.redhat.com
 const API_ROOT = process.env.REACT_APP_API_ROOT;

--- a/src/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import * as Yup from 'yup';
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  TextContent,
+  Text,
+  ModalBoxBody,
+  ModalBoxFooter,
+  AlertVariant,
+  Alert,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
+import Axios, { CancelTokenSource } from 'axios';
+import { InputField, TextAreaField } from '../ui/formik';
+import { Formik, FormikHelpers } from 'formik';
+import { createClusterDownloadsImage } from '../../api/clusters';
+import { LoadingState } from '../ui/uiState';
+import { handleApiError, getErrorMessage } from '../../api/utils';
+import { ImageCreateParams, ImageInfo, Cluster } from '../../api/types';
+import { sshPublicKeyValidationSchema } from '../ui/formik/validationSchemas';
+import GridGap from '../ui/GridGap';
+
+const validationSchema = Yup.object().shape({
+  proxyUrl: Yup.string().url('Provide a valid URL.'),
+  sshPublicKey: sshPublicKeyValidationSchema.required(
+    'SSH key is required for debugging the host registration.',
+  ),
+});
+
+type DiscoveryImageFormProps = {
+  clusterId: Cluster['id'];
+  imageInfo: ImageInfo;
+  onCancel: () => void;
+  onSuccess: () => void;
+};
+
+const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
+  clusterId,
+  imageInfo,
+  onCancel,
+  onSuccess,
+}) => {
+  const cancelSourceRef = React.useRef<CancelTokenSource>();
+  const { proxyUrl, sshPublicKey } = imageInfo;
+
+  React.useEffect(() => {
+    cancelSourceRef.current = Axios.CancelToken.source();
+    return () => cancelSourceRef.current?.cancel('Image generation cancelled by user.');
+  }, []);
+
+  const handleSubmit = async (
+    values: ImageCreateParams,
+    formikActions: FormikHelpers<ImageCreateParams>,
+  ) => {
+    if (clusterId) {
+      try {
+        await createClusterDownloadsImage(clusterId, values, {
+          cancelToken: cancelSourceRef.current?.token,
+        });
+        onSuccess();
+      } catch (error) {
+        handleApiError<ImageCreateParams>(error, () => {
+          formikActions.setStatus({
+            error: {
+              title: 'Failed to download the discovery Image',
+              message: getErrorMessage(error),
+            },
+          });
+        });
+      }
+    }
+  };
+  return (
+    <Formik
+      initialValues={{ proxyUrl, sshPublicKey } as ImageCreateParams}
+      initialStatus={{ error: null }}
+      validationSchema={validationSchema}
+      onSubmit={handleSubmit}
+    >
+      {({ handleSubmit, isSubmitting, status, setStatus }) =>
+        isSubmitting ? (
+          <LoadingState
+            content="Discovery image is being prepared, it will be available in a moment..."
+            secondaryActions={[
+              <Button key="close" variant={ButtonVariant.secondary} onClick={onCancel}>
+                Cancel
+              </Button>,
+            ]}
+          />
+        ) : (
+          <Form onSubmit={handleSubmit}>
+            <ModalBoxBody>
+              <GridGap>
+                {status.error && (
+                  <Alert
+                    variant={AlertVariant.danger}
+                    title={status.error.title}
+                    actionClose={
+                      <AlertActionCloseButton onClose={() => setStatus({ error: null })} />
+                    }
+                    isInline
+                  >
+                    {status.error.message}
+                  </Alert>
+                )}
+                <TextContent>
+                  <Text component="p">
+                    Hosts must be connected to the internet to form a cluster using this installer.
+                    If hosts are behind a firewall that requires the use of a proxy, provide the
+                    proxy URL below.
+                  </Text>
+                  <Text component="p">
+                    Each host will need a valid IP address assigned by a DHCP server with DNS
+                    records that fully resolve.
+                  </Text>
+                  <Text component="p">
+                    The Discovery ISO should only be booted once per host. Either adjust the boot
+                    order in each host's BIOS to make it secondary after the first alpabetical disk,
+                    or select the ISO once manually. All other disks in the host will be wiped
+                    during the installation.
+                  </Text>
+                </TextContent>
+                <InputField
+                  label="HTTP Proxy URL"
+                  name="proxyUrl"
+                  placeholder="http://<user>:<password>@<ipaddr>:<port>"
+                  helperText="HTTP proxy URL that agents should use to access the discovery service"
+                />
+                <TextAreaField
+                  label="SSH public key"
+                  name="sshPublicKey"
+                  helperText="SSH public key for debugging the host registration/installation"
+                  isRequired
+                />
+              </GridGap>
+            </ModalBoxBody>
+            <ModalBoxFooter>
+              <Button key="submit" type="submit">
+                Get Discovery ISO
+              </Button>
+              <Button key="cancel" variant="link" onClick={onCancel}>
+                Cancel
+              </Button>
+            </ModalBoxFooter>
+          </Form>
+        )
+      }
+    </Formik>
+  );
+};
+
+export default DiscoveryImageForm;

--- a/src/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -33,7 +33,7 @@ type DiscoveryImageFormProps = {
   clusterId: Cluster['id'];
   imageInfo: ImageInfo;
   onCancel: () => void;
-  onSuccess: () => void;
+  onSuccess: (imageInfo: Cluster['imageInfo']) => void;
 };
 
 const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
@@ -56,10 +56,10 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
   ) => {
     if (clusterId) {
       try {
-        await createClusterDownloadsImage(clusterId, values, {
+        const { data: cluster } = await createClusterDownloadsImage(clusterId, values, {
           cancelToken: cancelSourceRef.current?.token,
         });
-        onSuccess();
+        onSuccess(cluster.imageInfo);
       } catch (error) {
         handleApiError<ImageCreateParams>(error, () => {
           formikActions.setStatus({
@@ -72,9 +72,15 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
       }
     }
   };
+
+  const initialValues = {
+    proxyUrl: proxyUrl || '',
+    sshPublicKey: sshPublicKey || '',
+  };
+
   return (
     <Formik
-      initialValues={{ proxyUrl, sshPublicKey } as ImageCreateParams}
+      initialValues={initialValues as ImageCreateParams}
       initialStatus={{ error: null }}
       validationSchema={validationSchema}
       onSubmit={handleSubmit}

--- a/src/components/clusterConfiguration/DiscoveryImageSummary.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageSummary.tsx
@@ -21,18 +21,21 @@ import { DetailList, DetailItem } from '../ui/DetailList';
 
 type DiscoveryImageSummaryProps = {
   clusterId: Cluster['id'];
+  imageInfo: Cluster['imageInfo'];
   onClose: () => void;
   onReset: () => void;
 };
 
 const DiscoveryImageSummary: React.FC<DiscoveryImageSummaryProps> = ({
   clusterId,
+  imageInfo,
   onClose,
   onReset,
 }) => {
   const isoPath = getClusterDownloadsImageUrl(clusterId);
   const isoUrl = `${window.location.origin}${isoPath}`;
   const downloadIso = () => saveAs(isoPath);
+  const { proxyUrl } = imageInfo;
   return (
     <>
       <ModalBoxBody>
@@ -52,6 +55,7 @@ const DiscoveryImageSummary: React.FC<DiscoveryImageSummaryProps> = ({
                 </ClipboardCopy>
               }
             />
+            {proxyUrl && <DetailItem title="HTTP Proxy URL" value={proxyUrl} />}
           </DetailList>
         </TextContent>
       </ModalBoxBody>

--- a/src/components/clusterConfiguration/DiscoveryImageSummary.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageSummary.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { saveAs } from 'file-saver';
+import {
+  Button,
+  ButtonVariant,
+  ClipboardCopy,
+  clipboardCopyFunc,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateVariant,
+  Title,
+  ModalBoxBody,
+  ModalBoxFooter,
+  TextContent,
+} from '@patternfly/react-core';
+import { global_success_color_100 as successColor } from '@patternfly/react-tokens';
+import { CheckCircleIcon } from '@patternfly/react-icons';
+import { Cluster } from '../../api/types';
+import { getClusterDownloadsImageUrl } from '../../api/clusters';
+import { DetailList, DetailItem } from '../ui/DetailList';
+
+type DiscoveryImageSummaryProps = {
+  clusterId: Cluster['id'];
+  onClose: () => void;
+  onReset: () => void;
+};
+
+const DiscoveryImageSummary: React.FC<DiscoveryImageSummaryProps> = ({
+  clusterId,
+  onClose,
+  onReset,
+}) => {
+  const isoPath = getClusterDownloadsImageUrl(clusterId);
+  const isoUrl = `${window.location.origin}${isoPath}`;
+  const downloadIso = () => saveAs(isoPath);
+  return (
+    <>
+      <ModalBoxBody>
+        <EmptyState variant={EmptyStateVariant.small}>
+          <EmptyStateIcon icon={CheckCircleIcon} color={successColor.value} />
+          <Title headingLevel="h4" size="lg">
+            Discovery ISO is ready to download
+          </Title>
+        </EmptyState>
+        <TextContent>
+          <DetailList>
+            <DetailItem
+              title="Discovery ISO URL"
+              value={
+                <ClipboardCopy isReadOnly onCopy={(event) => clipboardCopyFunc(event, isoUrl)}>
+                  {isoUrl}
+                </ClipboardCopy>
+              }
+            />
+          </DetailList>
+        </TextContent>
+      </ModalBoxBody>
+      <ModalBoxFooter>
+        <Button variant={ButtonVariant.primary} onClick={downloadIso}>
+          Download Discovery ISO
+        </Button>
+        <Button variant={ButtonVariant.secondary} onClick={onClose}>
+          Close
+        </Button>
+        <Button variant={ButtonVariant.link} onClick={onReset}>
+          Edit ISO Configuration
+        </Button>
+      </ModalBoxFooter>
+    </>
+  );
+};
+
+export default DiscoveryImageSummary;

--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useParams } from 'react-router-dom';
 import { Modal, Button, ButtonVariant, ModalVariant } from '@patternfly/react-core';
 import { ToolbarButton } from '../ui/Toolbar';
-import { ImageInfo } from '../../api/types';
+import { ImageInfo, Cluster } from '../../api/types';
 import DiscoveryImageForm from './DiscoveryImageForm';
 import DiscoveryImageSummary from './DiscoveryImageSummary';
 
@@ -28,21 +28,21 @@ export const DiscoveryImageModalButton: React.FC<DiscoveryImageModalButtonProps>
       >
         Download discovery ISO
       </ButtonComponent>
-      {isModalOpen && <DiscoveryImageModal closeModal={closeModal} imageInfo={imageInfo} />}
+      {isModalOpen && <DiscoveryImageModal closeModal={closeModal} initialImageInfo={imageInfo} />}
     </>
   );
 };
 
 type DiscoveryImageModalProps = {
   closeModal: () => void;
-  imageInfo: ImageInfo;
+  initialImageInfo: ImageInfo;
 };
 
 export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
   closeModal,
-  imageInfo,
+  initialImageInfo,
 }) => {
-  const [imageReady, setImageReady] = React.useState(false);
+  const [imageInfo, setImageInfo] = React.useState<Cluster['imageInfo'] | undefined>();
   const { clusterId } = useParams();
 
   return (
@@ -54,18 +54,19 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
       variant={ModalVariant.small}
       hasNoBodyWrapper
     >
-      {imageReady ? (
+      {imageInfo ? (
         <DiscoveryImageSummary
           clusterId={clusterId}
+          imageInfo={imageInfo}
           onClose={closeModal}
-          onReset={() => setImageReady(false)}
+          onReset={() => setImageInfo(undefined)}
         />
       ) : (
         <DiscoveryImageForm
-          imageInfo={imageInfo}
+          imageInfo={initialImageInfo}
           clusterId={clusterId}
           onCancel={closeModal}
-          onSuccess={() => setImageReady(true)}
+          onSuccess={(imageInfo: Cluster['imageInfo']) => setImageInfo(imageInfo)}
         />
       )}
     </Modal>

--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -1,29 +1,10 @@
 import React from 'react';
-import Axios, { CancelTokenSource } from 'axios';
-import * as Yup from 'yup';
-import {
-  Modal,
-  Button,
-  ButtonVariant,
-  Form,
-  TextContent,
-  Text,
-  ModalBoxFooter,
-  AlertVariant,
-  Alert,
-  AlertActionCloseButton,
-  ModalVariant,
-} from '@patternfly/react-core';
-import { saveAs } from 'file-saver';
-import { ToolbarButton } from '../ui/Toolbar';
-import { InputField, TextAreaField } from '../ui/formik';
-import { Formik, FormikHelpers } from 'formik';
-import { createClusterDownloadsImage, getClusterDownloadsImageUrl } from '../../api/clusters';
 import { useParams } from 'react-router-dom';
-import { LoadingState } from '../ui/uiState';
-import { handleApiError, getErrorMessage } from '../../api/utils';
-import { ImageCreateParams, ImageInfo } from '../../api/types';
-import { sshPublicKeyValidationSchema } from '../ui/formik/validationSchemas';
+import { Modal, Button, ButtonVariant, ModalVariant } from '@patternfly/react-core';
+import { ToolbarButton } from '../ui/Toolbar';
+import { ImageInfo } from '../../api/types';
+import DiscoveryImageForm from './DiscoveryImageForm';
+import DiscoveryImageSummary from './DiscoveryImageSummary';
 
 type DiscoveryImageModalButtonProps = {
   ButtonComponent?: typeof Button | typeof ToolbarButton;
@@ -52,13 +33,6 @@ export const DiscoveryImageModalButton: React.FC<DiscoveryImageModalButtonProps>
   );
 };
 
-const validationSchema = Yup.object().shape({
-  proxyUrl: Yup.string().url('Provide a valid URL.'),
-  sshPublicKey: sshPublicKeyValidationSchema.required(
-    'SSH key is required for debugging the host registration.',
-  ),
-});
-
 type DiscoveryImageModalProps = {
   closeModal: () => void;
   imageInfo: ImageInfo;
@@ -68,119 +42,32 @@ export const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({
   closeModal,
   imageInfo,
 }) => {
-  const cancelSourceRef = React.useRef<CancelTokenSource>();
+  const [imageReady, setImageReady] = React.useState(false);
   const { clusterId } = useParams();
-  const { proxyUrl, sshPublicKey } = imageInfo;
-
-  React.useEffect(() => {
-    cancelSourceRef.current = Axios.CancelToken.source();
-    return () => cancelSourceRef.current?.cancel('Image generation cancelled by user.');
-  }, []);
-
-  const handleSubmit = async (
-    values: ImageCreateParams,
-    formikActions: FormikHelpers<ImageCreateParams>,
-  ) => {
-    if (clusterId) {
-      try {
-        await createClusterDownloadsImage(clusterId, values, {
-          cancelToken: cancelSourceRef.current?.token,
-        });
-        saveAs(getClusterDownloadsImageUrl(clusterId), `discovery-image-${clusterId}.iso`);
-        closeModal();
-      } catch (error) {
-        handleApiError<ImageCreateParams>(error, () => {
-          formikActions.setStatus({
-            error: {
-              title: 'Failed to download the discovery Image',
-              message: getErrorMessage(error),
-            },
-          });
-        });
-      }
-    }
-  };
 
   return (
     <Modal
+      aria-label="Download discovery ISO dialog"
       title="Download discovery ISO"
       isOpen={true}
       onClose={closeModal}
       variant={ModalVariant.small}
+      hasNoBodyWrapper
     >
-      <Formik
-        initialValues={{ proxyUrl, sshPublicKey } as ImageCreateParams}
-        initialStatus={{ error: null }}
-        validationSchema={validationSchema}
-        onSubmit={handleSubmit}
-      >
-        {({ handleSubmit, isSubmitting, status, setStatus }) => (
-          <Form onSubmit={handleSubmit}>
-            {isSubmitting ? (
-              <LoadingState
-                content="Discovery image is being prepared, the download will start in a moment."
-                secondaryActions={[
-                  <Button key="close" variant={ButtonVariant.secondary} onClick={closeModal}>
-                    Cancel
-                  </Button>,
-                ]}
-              />
-            ) : (
-              <>
-                {status.error && (
-                  <Alert
-                    variant={AlertVariant.danger}
-                    title={status.error.title}
-                    actionClose={
-                      <AlertActionCloseButton onClose={() => setStatus({ error: null })} />
-                    }
-                    isInline
-                  >
-                    {status.error.message}
-                  </Alert>
-                )}
-                <TextContent>
-                  <Text component="p">
-                    Hosts must be connected to the internet to form a cluster using this installer.
-                    If hosts are behind a firewall that requires the use of a proxy, provide the
-                    proxy URL below.
-                  </Text>
-                  <Text component="p">
-                    Each host will need a valid IP address assigned by a DHCP server with DNS
-                    records that fully resolve.
-                  </Text>
-                  <Text component="p">
-                    The Discovery ISO should only be booted once per host. Either adjust the boot
-                    order in each host's BIOS to make it secondary after the first alpabetical disk,
-                    or select the ISO once manually. All other disks in the host will be wiped
-                    during the installation.
-                  </Text>
-                </TextContent>
-                <InputField
-                  label="HTTP Proxy URL"
-                  name="proxyUrl"
-                  placeholder="http://<user>:<password>@<ipaddr>:<port>"
-                  helperText="HTTP proxy URL that agents should use to access the discovery service"
-                />
-                <TextAreaField
-                  label="SSH public key"
-                  name="sshPublicKey"
-                  helperText="SSH public key for debugging the host registration/installation"
-                  isRequired
-                />
-                <ModalBoxFooter>
-                  <Button key="submit" type="submit">
-                    Download Discovery ISO
-                  </Button>
-                  <Button key="cancel" variant="link" onClick={closeModal}>
-                    Cancel
-                  </Button>
-                </ModalBoxFooter>
-              </>
-            )}
-          </Form>
-        )}
-      </Formik>
+      {imageReady ? (
+        <DiscoveryImageSummary
+          clusterId={clusterId}
+          onClose={closeModal}
+          onReset={() => setImageReady(false)}
+        />
+      ) : (
+        <DiscoveryImageForm
+          imageInfo={imageInfo}
+          clusterId={clusterId}
+          onCancel={closeModal}
+          onSuccess={() => setImageReady(true)}
+        />
+      )}
     </Modal>
   );
 };


### PR DESCRIPTION
This changes the discovery modal behavior - after the download is ready
the modal does not close and provides an ISO URL to be coppied and a button
to trigger a download via browser.

![iso-download-final](https://user-images.githubusercontent.com/1121740/85847838-6f6ca000-b7a8-11ea-86af-3364323e603b.gif)

