### PR TITLE
Update events wording

### DIFF
--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -324,7 +324,7 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({
                   variant={ButtonVariant.link}
                   style={{ textAlign: 'right' }}
                 >
-                  View Cluster Events History
+                  View Cluster Events
                 </EventsModalButton>
               </ToolbarSecondaryGroup>
             </ClusterToolbar>

--- a/src/components/clusterDetail/ClusterDetail.tsx
+++ b/src/components/clusterDetail/ClusterDetail.tsx
@@ -138,7 +138,7 @@ const ClusterDetail: React.FC<ClusterDetailProps> = ({
             variant={ButtonVariant.link}
             style={{ textAlign: 'right' }}
           >
-            View Cluster Events History
+            View Cluster Events
           </EventsModalButton>
         </ToolbarSecondaryGroup>
       </ClusterToolbar>

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -233,7 +233,7 @@ const HostsTable: React.FC<HostsTableProps> = ({ cluster }) => {
         });
       }
       actions.push({
-        title: 'View Host Events History',
+        title: 'View Host Events',
         id: `button-view-host-events-${hostname}`,
         onClick: onViewHostEvents,
       });
@@ -283,9 +283,9 @@ const HostsTable: React.FC<HostsTableProps> = ({ cluster }) => {
         <TableBody rowKey={rowKey} />
       </Table>
       <EventsModal
-        title={`Events for the ${
+        title={`Host Events: ${
           getHostInventory(showEventsModal)?.hostname || showEventsModal
-        } host`}
+        }`}
         entityKind="host"
         entityId={showEventsModal}
         onClose={() => setShowEventsModal('')}


### PR DESCRIPTION
Tweaks:
- Removes the word "History" to be more concise but still clear (and align with OCP's wording a bit, even though those events are different)
- Rephrases `Events for the X host` to `Host Events: X` to be more concise, clear, and align with `Cluster Events`