### PR TITLE
Adjust DNS checkbox label

### DIFF
--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -51,7 +51,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       {!!managedDomains.length && (
         <CheckboxField
           name="useRedHatDnsService"
-          label="Use Red Hat's DNS service"
+          label="Use a temporary DNS domain from Red Hat"
           helperText="A base DNS domain will be provided by Red Hat's DNS service. Because the cluster's DNS can't be changed after cluster installation, this should only be used for temporary, non-production clusters."
           onChange={toggleRedHatDnsService}
         />


### PR DESCRIPTION
Based on some feedback we received:

> nit: I would change from Red Hat DNS service to "Temporary OpenShift POC domain name"?

I tweaked this suggestion a bit to avoid saying POC (which we would have to spell out) while still emphasizing even further that this option should only be used for temporary clusters.

## Before

![image](https://user-images.githubusercontent.com/9122899/88466405-f1301600-ce99-11ea-90b2-819c744e714e.png)

## After

![image](https://user-images.githubusercontent.com/9122899/88466409-fbeaab00-ce99-11ea-91e3-94c96f8a2e9a.png)