### PR TITLE
Make html element IDs unique

### DIFF
--- a/src/components/clusterConfiguration/ClusterSshKeyField.tsx
+++ b/src/components/clusterConfiguration/ClusterSshKeyField.tsx
@@ -28,10 +28,11 @@ const ClusterSshKeyField: React.FC<ClusterSshKeyFieldProps> = ({
   isSwitchHidden,
   onToggle,
   onClusterSshKeyVisibilityChanged,
+  idPostfix,
   ...props
 }) => {
   const [field] = useField({ name: props.name, validate });
-  const fieldId = getFieldId(props.name, 'input');
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
 
   React.useEffect(onClusterSshKeyVisibilityChanged, [isSwitchHidden]);
 

--- a/src/components/clusterConfiguration/DiscoveryImageForm.tsx
+++ b/src/components/clusterConfiguration/DiscoveryImageForm.tsx
@@ -143,6 +143,7 @@ const DiscoveryImageForm: React.FC<DiscoveryImageFormProps> = ({
                   label="Host SSH public key for troubleshooting during discovery"
                   name="sshPublicKey"
                   helperText="Provide a public key to debug any hosts that fail to register successfuly."
+                  idPostfix="discovery"
                   isRequired
                 />
               </GridGap>

--- a/src/components/ui/formik/CheckboxField.tsx
+++ b/src/components/ui/formik/CheckboxField.tsx
@@ -10,10 +10,11 @@ const CheckboxField: React.FC<CheckboxFieldProps> = ({
   helperText,
   onChange,
   validate,
+  idPostfix,
   ...props
 }) => {
   const [field] = useField({ name: props.name, validate });
-  const fieldId = getFieldId(props.name, 'input');
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
   return (
     <Checkbox
       {...field}

--- a/src/components/ui/formik/InputField.tsx
+++ b/src/components/ui/formik/InputField.tsx
@@ -11,10 +11,11 @@ const InputField: React.FC<InputFieldProps> = ({
   isRequired,
   onChange,
   validate,
+  idPostfix,
   ...props
 }) => {
   const [field, { touched, error }] = useField({ name: props.name, validate });
-  const fieldId = getFieldId(props.name, 'input');
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
   return (

--- a/src/components/ui/formik/SelectField.tsx
+++ b/src/components/ui/formik/SelectField.tsx
@@ -12,10 +12,11 @@ const SelectField: React.FC<SelectFieldProps> = ({
   isRequired,
   onChange,
   getHelperText,
+  idPostfix,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
-  const fieldId = getFieldId(props.name, 'input');
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
   const isValid = !(touched && error);
   const errorMessage = !isValid ? error : '';
   const hText = getHelperText ? getHelperText(field.value) : helperText;

--- a/src/components/ui/formik/TextAreaField.tsx
+++ b/src/components/ui/formik/TextAreaField.tsx
@@ -11,10 +11,11 @@ const TextAreaField: React.FC<TextAreaProps> = ({
   getErrorText,
   isRequired,
   children,
+  idPostfix,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
-  const fieldId = getFieldId(props.name, 'input');
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
   const isValid = !(touched && error);
 
   const getErrorMessage = () => {

--- a/src/components/ui/formik/TextAreaSecretField.tsx
+++ b/src/components/ui/formik/TextAreaSecretField.tsx
@@ -9,10 +9,11 @@ const TextAreaSecretField: React.FC<TextAreaSecretProps> = ({
   isEdit,
   helperTextHidden,
   onToggle,
+  idPostfix,
   ...props
 }) => {
   const { label, name } = props;
-  const fieldId = getFieldId(name, 'input');
+  const fieldId = getFieldId(name, 'input', idPostfix);
 
   if (isEdit) {
     return (

--- a/src/components/ui/formik/types.ts
+++ b/src/components/ui/formik/types.ts
@@ -17,6 +17,7 @@ export interface FieldProps {
   validate?: FieldValidator;
   min?: number;
   max?: number;
+  idPostfix?: string;
 }
 
 export interface SelectFieldProps extends FieldProps {

--- a/src/components/ui/formik/utils.ts
+++ b/src/components/ui/formik/utils.ts
@@ -1,3 +1,4 @@
-export const getFieldId = (fieldName: string, fieldType: string) => {
-  return `form-${fieldType}-${fieldName.replace(/\./g, '-')}-field`;
+export const getFieldId = (fieldName: string, fieldType: string, unique?: string) => {
+  unique = unique ? `${unique}-` : '';
+  return `form-${fieldType}-${fieldName.replace(/\./g, '-')}-${unique}field`;
 };


### PR DESCRIPTION
Fixes conflicting IDs in case of a modal rendered over a form, both containing the same element ID.

Example for the SSH public key:
- `form-input-sshPublicKey-discovery-field` in the Disccovery ISO modal
- `form-input-sshPublicKey-field` - on the Cluster configuration page

Prior this patch, these two element IDs were equal.