### PR TITLE
Let typescript guard missing status icons

### DIFF
--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -9,7 +9,6 @@ import {
   ExclamationCircleIcon,
   WarningTriangleIcon,
   CheckCircleIcon,
-  UnknownIcon,
   InProgressIcon,
 } from '@patternfly/react-icons';
 import { Cluster } from '../../api/types';
@@ -20,14 +19,23 @@ type ClusterStatusProps = {
   cluster: Cluster;
 };
 
-const getStatusIcon = (status: Cluster['status']) => {
-  if (status === 'insufficient') return <WarningTriangleIcon color={warningColor.value} />;
-  if (status === 'ready') return <CheckCircleIcon color={okColor.value} />;
-  if (status === 'preparing-for-installation') return <InProgressIcon />;
-  if (status === 'installing') return <InProgressIcon />;
-  if (status === 'error') return <ExclamationCircleIcon color={dangerColor.value} />;
-  if (status === 'installed') return <CheckCircleIcon color={okColor.value} />;
-  return <UnknownIcon />;
+const getStatusIcon = (status: Cluster['status']): React.ReactElement => {
+  switch (status) {
+    case 'insufficient':
+      return <WarningTriangleIcon color={warningColor.value} />;
+    case 'ready':
+      return <CheckCircleIcon color={okColor.value} />;
+    case 'preparing-for-installation':
+      return <InProgressIcon />;
+    case 'installing':
+      return <InProgressIcon />;
+    case 'error':
+      return <ExclamationCircleIcon color={dangerColor.value} />;
+    case 'installed':
+      return <CheckCircleIcon color={okColor.value} />;
+    case 'finalizing':
+      return <InProgressIcon />;
+  }
 };
 
 export const getClusterStatusText = (cluster: Cluster) =>
@@ -36,7 +44,7 @@ export const getClusterStatusText = (cluster: Cluster) =>
 const ClusterStatus: React.FC<ClusterStatusProps> = ({ cluster }) => {
   const { status, statusInfo, statusUpdatedAt } = cluster;
   const title = getClusterStatusText(cluster);
-  const icon = getStatusIcon(status);
+  const icon = getStatusIcon(status) || null;
   if (statusInfo) {
     return (
       <Popover

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -13,7 +13,6 @@ import {
   DisconnectedIcon,
   ConnectedIcon,
   BanIcon,
-  UnknownIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
 import { Host } from '../../api/types';
@@ -28,24 +27,37 @@ import { stringToJSON } from '../../api/utils';
 import './HostStatus.css';
 import HostValidationGroups from './HostValidationGroups';
 
-const getStatusIcon = (status: Host['status']) => {
-  if (status === 'discovering') return <ConnectedIcon />;
-  if (status === 'pending-for-input') return <PendingIcon />;
-  if (status === 'known') return <CheckCircleIcon color={okColor.value} />;
-  if (status === 'disconnected') return <DisconnectedIcon />;
-  if (status === 'disabled') return <BanIcon />;
-  if (status === 'insufficient') return <WarningTriangleIcon color={warningColor.value} />;
-  if (status === 'preparing-for-installation') return <InProgressIcon />;
-  if (status === 'installing') return <InProgressIcon />;
-  if (status === 'installing-in-progress') return <InProgressIcon />;
-  if (status === 'installing-pending-user-action')
-    return <WarningTriangleIcon color={warningColor.value} />;
-  if (status === 'error') return <ExclamationCircleIcon color={dangerColor.value} />;
-  if (status === 'installed') return <CheckCircleIcon color={okColor.value} />;
-  if (status === 'resetting') return <InProgressIcon />;
-  if (status === 'resetting-pending-user-action')
-    return <WarningTriangleIcon color={warningColor.value} />;
-  return <UnknownIcon />;
+const getStatusIcon = (status: Host['status']): React.ReactElement => {
+  switch (status) {
+    case 'discovering':
+      return <ConnectedIcon />;
+    case 'pending-for-input':
+      return <PendingIcon />;
+    case 'known':
+      return <CheckCircleIcon color={okColor.value} />;
+    case 'disconnected':
+      return <DisconnectedIcon />;
+    case 'disabled':
+      return <BanIcon />;
+    case 'insufficient':
+      return <WarningTriangleIcon color={warningColor.value} />;
+    case 'preparing-for-installation':
+      return <InProgressIcon />;
+    case 'installing':
+      return <InProgressIcon />;
+    case 'installing-in-progress':
+      return <InProgressIcon />;
+    case 'installing-pending-user-action':
+      return <WarningTriangleIcon color={warningColor.value} />;
+    case 'error':
+      return <ExclamationCircleIcon color={dangerColor.value} />;
+    case 'installed':
+      return <CheckCircleIcon color={okColor.value} />;
+    case 'resetting':
+      return <InProgressIcon />;
+    case 'resetting-pending-user-action':
+      return <WarningTriangleIcon color={warningColor.value} />;
+  }
 };
 
 const getPopoverContent = (host: Host) => {
@@ -100,7 +112,7 @@ type HostStatusProps = {
 const HostStatus: React.FC<HostStatusProps> = ({ host }) => {
   const { status, statusUpdatedAt } = host;
   const title = HOST_STATUS_LABELS[status] || status;
-  const icon = getStatusIcon(status);
+  const icon = getStatusIcon(status) || null;
   const hostProgressStages = getHostProgressStages(host);
 
   return (


### PR DESCRIPTION
Typescript will fail if new cluster/host status is added to the API
but list of icons does not reflect that.

Cluster in "finalizing" is fixed.