### PR TITLE
CIDR fields are required

### DIFF
--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -50,16 +50,16 @@ import { getInitialValues, getHostSubnets, findMatchingSubnet } from './utils';
 import { AlertsContext } from '../AlertsContextProvider';
 import ClusterSshKeyField from './ClusterSshKeyField';
 
-const validationSchema = (hostSubnets: HostSubnets) =>
+const validationSchema = (initialValues: ClusterConfigurationValues, hostSubnets: HostSubnets) =>
   Yup.lazy<ClusterConfigurationValues>((values) =>
     Yup.object<ClusterConfigurationValues>().shape({
       name: nameValidationSchema,
-      baseDnsDomain: dnsNameValidationSchema,
+      baseDnsDomain: dnsNameValidationSchema(initialValues.baseDnsDomain),
       clusterNetworkHostPrefix: hostPrefixValidationSchema(values),
       clusterNetworkCidr: ipBlockValidationSchema,
       serviceNetworkCidr: ipBlockValidationSchema,
-      apiVip: vipValidationSchema(hostSubnets, values),
-      ingressVip: vipValidationSchema(hostSubnets, values),
+      apiVip: vipValidationSchema(hostSubnets, values, initialValues.apiVip),
+      ingressVip: vipValidationSchema(hostSubnets, values, initialValues.ingressVip),
       sshPublicKey: sshPublicKeyValidationSchema,
     }),
   );
@@ -86,9 +86,10 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({
     cluster,
     managedDomains,
   ]);
-  const memoizedValidationSchema = React.useMemo(() => validationSchema(hostSubnets), [
-    hostSubnets,
-  ]);
+  const memoizedValidationSchema = React.useMemo(
+    () => validationSchema(initialValues, hostSubnets),
+    [hostSubnets, initialValues],
+  );
 
   const handleSubmit = async (
     values: ClusterConfigurationValues,

--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -113,11 +113,6 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({
         params.sshPublicKey = cluster.imageInfo.sshPublicKey;
       }
 
-      // do not pass empty string since a number is expected (might happen when emptying input-box)
-      if (!params.clusterNetworkHostPrefix && params.clusterNetworkHostPrefix !== 0) {
-        delete params.clusterNetworkHostPrefix;
-      }
-
       const { data } = await patchCluster(cluster.id, params);
       formikActions.resetForm({
         values: getInitialValues(data, managedDomains),

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -80,11 +80,13 @@ export const vipValidationSchema = (hostSubnets: HostSubnets, values: ClusterCon
     vipUniqueValidationSchema(hostSubnets, values),
   );
 
-export const ipBlockValidationSchema = Yup.string().matches(IP_ADDRESS_BLOCK_REGEX, {
-  message:
-    'Value "${value}" is not valid IP block address, expected value is IP/netmask. Example: 123.123.123.0/24', // eslint-disable-line no-template-curly-in-string
-  excludeEmptyString: true,
-});
+export const ipBlockValidationSchema = Yup.string()
+  .required('A value is required.')
+  .matches(IP_ADDRESS_BLOCK_REGEX, {
+    message:
+      'Value "${value}" is not valid IP block address, expected value is IP/netmask. Example: 123.123.123.0/24', // eslint-disable-line no-template-curly-in-string
+    excludeEmptyString: true,
+  });
 
 export const dnsNameValidationSchema = Yup.string().matches(DNS_NAME_REGEX, {
   message: 'Value "${value}" is not valid DNS name. Example: basedomain.example.com', // eslint-disable-line no-template-curly-in-string
@@ -92,9 +94,11 @@ export const dnsNameValidationSchema = Yup.string().matches(DNS_NAME_REGEX, {
 });
 
 export const hostPrefixValidationSchema = (values: ClusterConfigurationValues) => {
+  const requiredText = 'The host prefix is required.';
   const netBlock = (values.clusterNetworkCidr || '').split('/')[1];
   if (!netBlock) {
     return Yup.number()
+      .required(requiredText)
       .min(1, `The host prefix is a number between 1 and 32.`)
       .max(32, `The host prefix is a number between 1 and 32.`);
   }
@@ -104,7 +108,7 @@ export const hostPrefixValidationSchema = (values: ClusterConfigurationValues) =
     netBlockNumber = 1;
   }
   const errorMsg = `The host prefix is a number between size of the cluster network CIDR range (${netBlockNumber}) and 32.`;
-  return Yup.number().min(netBlockNumber, errorMsg).max(32, errorMsg);
+  return Yup.number().required(requiredText).min(netBlockNumber, errorMsg).max(32, errorMsg);
 };
 
 export const hostnameValidationSchema = Yup.string().matches(HOSTNAME_REGEX, {


### PR DESCRIPTION
Backend provides defaults for them.

In addition, new `.requiredOnceSet()` validation schema is introduced and used for the `baseDNS` and both VIPs fields.