### PR TITLE
Add HTML IDs to cluster progress status info

### DIFF
--- a/src/components/clusterDetail/ClusterProgress.tsx
+++ b/src/components/clusterDetail/ClusterProgress.tsx
@@ -67,8 +67,16 @@ const ClusterProgress: React.FC<ClusterProgressProps> = ({ cluster }) => {
   return (
     <>
       <DetailList>
-        <DetailItem title="Started on" value={getHumanizedDateTime(cluster.installStartedAt)} />
-        <DetailItem title="Status" value={getInstallationStatus(cluster)} />
+        <DetailItem
+          title="Started on"
+          value={getHumanizedDateTime(cluster.installStartedAt)}
+          idPrefix="cluster-progress-started-on"
+        />
+        <DetailItem
+          title="Status"
+          value={getInstallationStatus(cluster)}
+          idPrefix="cluster-progress-status"
+        />
       </DetailList>
       <Progress
         value={progressPercent}

--- a/src/components/ui/DetailList.tsx
+++ b/src/components/ui/DetailList.tsx
@@ -25,6 +25,7 @@ export type DetailItemProps = {
         value?: string;
       }[]
     | React.ReactNode;
+  idPrefix?: string;
 };
 
 export const DetailList: React.FC<DetailListProps> = ({
@@ -40,26 +41,32 @@ export const DetailList: React.FC<DetailListProps> = ({
   </TextContent>
 );
 
-export const DetailItem: React.FC<DetailItemProps> = ({ title, value = '' }) => {
-  return (
-    <>
-      <TextListItem component={TextListItemVariants.dt}>{title}</TextListItem>
-      <TextListItem component={TextListItemVariants.dd}>
-        {Array.isArray(value) ? (
-          <TextList component={TextListVariants.dl}>
-            {value.map((item) => [
-              <TextListItem key={item.title} component={TextListItemVariants.dt}>
-                {item.title}
-              </TextListItem>,
-              <TextListItem key={`dd-${item.title}`} component={TextListItemVariants.dd}>
-                {item.value}
-              </TextListItem>,
-            ])}
-          </TextList>
-        ) : (
-          value
-        )}
-      </TextListItem>
-    </>
-  );
-};
+export const DetailItem: React.FC<DetailItemProps> = ({ title, value = '', idPrefix }) => (
+  <>
+    <TextListItem
+      component={TextListItemVariants.dt}
+      id={idPrefix ? `${idPrefix}-title` : undefined}
+    >
+      {title}
+    </TextListItem>
+    <TextListItem
+      component={TextListItemVariants.dd}
+      id={idPrefix ? `${idPrefix}-value` : undefined}
+    >
+      {Array.isArray(value) ? (
+        <TextList component={TextListVariants.dl}>
+          {value.map((item) => [
+            <TextListItem key={item.title} component={TextListItemVariants.dt}>
+              {item.title}
+            </TextListItem>,
+            <TextListItem key={`dd-${item.title}`} component={TextListItemVariants.dd}>
+              {item.value}
+            </TextListItem>,
+          ])}
+        </TextList>
+      ) : (
+        value
+      )}
+    </TextListItem>
+  </>
+);


### PR DESCRIPTION
With this patch the cluster status HTML element on the cluster detail page looks like:
```
<dd id="cluster-progress-status-value" data-pf-content="true" class="">Installing</dd>
````