### PR TITLE
Add backend-based cluster validations

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,4 +1,5 @@
 import Axios, { AxiosError } from 'axios';
+import _ from 'lodash';
 
 type OnError = <T>(arg0: AxiosError<T>) => void;
 
@@ -29,15 +30,12 @@ export const handleApiError = <T>(error: AxiosError<T>, onError?: OnError) => {
 export const getErrorMessage = (error: AxiosError) =>
   error.response?.data?.reason || error.response?.data?.message || error.message;
 
-const toCamelCase = (str: string): string =>
-  str.replace(/([-_][a-z])/g, (group) => group.toUpperCase().replace('_', ''));
-
 export const stringToJSON = <T>(string: string | undefined): T | undefined => {
   if (string) {
     try {
       const camelCased = string.replace(
-        /"([\w]+)":/g,
-        (_match, offset) => `"${toCamelCase(offset)}":`,
+        /"([\w-]+)":/g,
+        (_match, offset) => `"${_.camelCase(offset)}":`,
       );
       const json = JSON.parse(camelCased);
       return json;

--- a/src/components/clusterConfiguration/clusterValidations.ts
+++ b/src/components/clusterConfiguration/clusterValidations.ts
@@ -7,28 +7,6 @@ import { sshPublicKeyValidationSchema } from '../ui/formik/validationSchemas';
 import { getInitialValues } from './utils';
 import { CLUSTER_FIELD_LABELS } from '../../config/constants';
 
-const validateHosts = (cluster: Cluster) => {
-  const hosts = cluster.hosts || [];
-  const masters = hosts.filter((r) => r.role === 'master').length;
-  if (hosts.length < 3) {
-    return `Cluster has insufficient number of hosts registered. Please register at least 3 hosts.`;
-  }
-  if (masters < 3) {
-    return `Cluster with ${masters} masters is not supported. Please choose at least 3 master hosts.`;
-  }
-  if (masters % 2 === 0) {
-    return `Cluster with ${masters} masters is not supported. Please set an odd number of master hosts.`;
-  }
-  const readyMasters = hosts.filter((host) => host.role === 'master' && host.status === 'known');
-  if (readyMasters.length < 3) {
-    return `Cluster has insufficient number of hosts ready for installation. Minimum of 3 master hosts in 'Known' state is required.`;
-  }
-  const notReadyHosts = hosts.filter((host) => !['known', 'disabled'].includes(host.status));
-  if (notReadyHosts.length) {
-    return `Not all hosts are ready for installation. Please disable or delete any hosts which are not intended for the deployment.`;
-  }
-};
-
 // TODO(jtomasek): Add validation to identify hosts which are connected to network defined by VIPs
 // const validateConnectedHosts = (cluster: Cluster) => ...;
 
@@ -64,5 +42,5 @@ const validateRequiredFields = (cluster: Cluster, managedDomains: ManagedDomain[
 };
 
 export const validateCluster = (cluster: Cluster, managedDomains: ManagedDomain[] = []) => {
-  return _.filter([validateHosts(cluster), validateRequiredFields(cluster, managedDomains)]);
+  return _.filter([validateRequiredFields(cluster, managedDomains)]);
 };

--- a/src/types/clusters.ts
+++ b/src/types/clusters.ts
@@ -1,6 +1,7 @@
 import { IRow } from '@patternfly/react-table';
 import { Netmask } from 'netmask';
 import { ClusterUpdateParams } from '../api/types';
+import { Validation } from './hosts';
 
 export type ClusterTableRows = IRow[];
 
@@ -14,4 +15,9 @@ export type ClusterConfigurationValues = ClusterUpdateParams & {
   hostSubnet: string;
   useRedHatDnsService: boolean;
   shareDiscoverySshKey: boolean;
+};
+
+export type ValidationsInfo = {
+  hostsData: Validation[];
+  network: Validation[];
 };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1121740/90729284-a356d400-e2c6-11ea-962b-831f9319a154.png)

The validation messages are taken directly from the backend and need polishing. Ideally we define validation messages on the client side and map them to backend validation id+status combination. This will allow easy i18n.