### PR TITLE
Add VIP DHCP configuration

### DIFF
--- a/src/components/clusterConfiguration/BasicNetworkFields.tsx
+++ b/src/components/clusterConfiguration/BasicNetworkFields.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { HostSubnets, ClusterConfigurationValues } from '../../types/clusters';
-import { InputField, SelectField } from '../ui/formik';
+import { InputField, SelectField, SwitchField } from '../ui/formik';
 import { useFormikContext } from 'formik';
 
 type BasicNetworkFieldsProps = {
   hostSubnets: HostSubnets;
+  isAdvanced: boolean;
 };
 
-const BasicNetworkFields: React.FC<BasicNetworkFieldsProps> = ({ hostSubnets }) => {
+const BasicNetworkFields: React.FC<BasicNetworkFieldsProps> = ({ hostSubnets, isAdvanced }) => {
   const { validateField, values } = useFormikContext<ClusterConfigurationValues>();
   const { hostSubnet } = values;
 
@@ -38,20 +39,25 @@ const BasicNetworkFields: React.FC<BasicNetworkFieldsProps> = ({ hostSubnets }) 
         }}
         isRequired
       />
-      <InputField
-        label="API Virtual IP"
-        name="apiVip"
-        helperText={`Virtual IP used to reach the OpenShift cluster API. Make sure that the VIP's are unique and not used by any other device on your network${subnet}.`}
-        isRequired
-        isDisabled={!hostSubnets.length}
-      />
-      <InputField
-        name="ingressVip"
-        label="Ingress Virtual IP"
-        helperText="Virtual IP used for cluster ingress traffic."
-        isRequired
-        isDisabled={!hostSubnets.length}
-      />
+      {isAdvanced && <SwitchField label="Use VIP DHCP allocation" name="vipDhcpAllocation" />}
+      {(!values.vipDhcpAllocation || !isAdvanced) && (
+        <>
+          <InputField
+            label="API Virtual IP"
+            name="apiVip"
+            helperText={`Virtual IP used to reach the OpenShift cluster API. Make sure that the VIP's are unique and not used by any other device on your network${subnet}.`}
+            isRequired
+            isDisabled={!hostSubnets.length}
+          />
+          <InputField
+            name="ingressVip"
+            label="Ingress Virtual IP"
+            helperText="Virtual IP used for cluster ingress traffic."
+            isRequired
+            isDisabled={!hostSubnets.length}
+          />
+        </>
+      )}
     </>
   );
 };

--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -114,6 +114,15 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({
         params.sshPublicKey = cluster.imageInfo.sshPublicKey;
       }
 
+      if (values.vipDhcpAllocation) {
+        delete params.apiVip;
+        delete params.ingressVip;
+        const cidr = hostSubnets
+          .find((hn) => hn.humanized === values.hostSubnet)
+          ?.subnet.toString();
+        params.machineNetworkCidr = cidr;
+      }
+
       const { data } = await patchCluster(cluster.id, params);
       formikActions.resetForm({
         values: getInitialValues(data, managedDomains),

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -16,8 +16,8 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
   hostSubnets,
   managedDomains,
 }) => {
-  const [type, setType] = React.useState<'basic' | 'advanced'>('basic');
   const { setFieldValue, initialValues, values } = useFormikContext<ClusterConfigurationValues>();
+  const [isAdvanced, setAdvanced] = React.useState<boolean>(!!values.vipDhcpAllocation);
   const { name: clusterName, baseDnsDomain, useRedHatDnsService } = values;
 
   const backToBasic = () => {
@@ -26,7 +26,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
     setFieldValue('clusterNetworkCidr', clusterNetworkCidr);
     setFieldValue('clusterNetworkHostPrefix', clusterNetworkHostPrefix);
     setFieldValue('serviceNetworkCidr', serviceNetworkCidr);
-    setType('basic');
+    setAdvanced(false);
   };
 
   const baseDnsHelperText = (
@@ -81,7 +81,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         <Radio
           id="networkConfigurationTypeBasic"
           name="networkConfigurationType"
-          isChecked={type === 'basic'}
+          isChecked={!isAdvanced}
           value="basic"
           onChange={backToBasic}
           label="Basic"
@@ -92,15 +92,15 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
           id="networkConfigurationTypeAdvanced"
           name="networkConfigurationType"
           value="advanced"
-          isChecked={type === 'advanced'}
-          onChange={() => setType('advanced')}
+          isChecked={isAdvanced}
+          onChange={() => setAdvanced(true)}
           label="Advanced"
           description="Configure a custom networking type and CIDR ranges."
           isLabelWrapped
         />
       </FormGroup>
-      <BasicNetworkFields hostSubnets={hostSubnets} />
-      {type === 'advanced' && <AdvancedNetworkFields />}
+      <BasicNetworkFields hostSubnets={hostSubnets} isAdvanced={isAdvanced} />
+      {isAdvanced && <AdvancedNetworkFields />}
     </>
   );
 };

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -45,7 +45,7 @@ export const getHostSubnets = (cluster: Cluster): HostSubnets => {
       return {
         subnet,
         hostIDs: hn.hostIds?.map((id) => hostnameMap[id] || id) || [],
-        humanized: `${subnet.first}-${subnet.last}`,
+        humanized: `${subnet.toString()} (${subnet.first}-${subnet.last})`,
       };
     }) || []
   );
@@ -68,4 +68,5 @@ export const getInitialValues = (
     !!cluster.baseDnsDomain && managedDomains.map((d) => d.domain).includes(cluster.baseDnsDomain),
   shareDiscoverySshKey:
     !!cluster.imageInfo.sshPublicKey && cluster.sshPublicKey === cluster.imageInfo.sshPublicKey,
+  vipDhcpAllocation: cluster.vipDhcpAllocation,
 });

--- a/src/components/ui/formik/SwitchField.tsx
+++ b/src/components/ui/formik/SwitchField.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { useField } from 'formik';
+import { FormGroup, Switch } from '@patternfly/react-core';
+import { getFieldId } from './utils';
+import { SwitchFieldProps } from './types';
+import HelperText from './HelperText';
+
+const SwitchField: React.FC<SwitchFieldProps> = ({
+  label,
+  helperText,
+  isRequired,
+  onChange,
+  getHelperText,
+  idPostfix,
+  ...props
+}) => {
+  const [field, { touched, error }] = useField(props.name);
+  const fieldId = getFieldId(props.name, 'input', idPostfix);
+  const isValid = !(touched && error);
+  const errorMessage = !isValid ? error : '';
+  const hText = getHelperText ? getHelperText(field.value) : helperText;
+  return (
+    <FormGroup
+      fieldId={fieldId}
+      helperText={
+        typeof hText === 'string' ? hText : <HelperText fieldId={fieldId}>{hText}</HelperText>
+      }
+      helperTextInvalid={errorMessage}
+      validated={isValid ? 'default' : 'error'}
+      isRequired={isRequired}
+    >
+      <Switch
+        {...field}
+        id={fieldId}
+        label={label}
+        isChecked={field.value}
+        onChange={(checked, event) => {
+          field.onChange(event);
+          onChange && onChange(checked, event);
+        }}
+      />
+    </FormGroup>
+  );
+};
+
+export default SwitchField;

--- a/src/components/ui/formik/index.tsx
+++ b/src/components/ui/formik/index.tsx
@@ -4,3 +4,4 @@ export { default as TextAreaField } from './TextAreaField';
 export { default as SelectField } from './SelectField';
 export { default as TextAreaSecretField } from './TextAreaSecretField';
 export { default as UploadField } from './UploadField';
+export { default as SwitchField } from './SwitchField';

--- a/src/components/ui/formik/types.ts
+++ b/src/components/ui/formik/types.ts
@@ -27,6 +27,11 @@ export interface SelectFieldProps extends FieldProps {
   // onBlur?: (event: React.FormEvent<HTMLSelectElement>) => void;
 }
 
+export interface SwitchFieldProps extends FieldProps {
+  onChange?: (checked: boolean, event: React.FormEvent<HTMLInputElement>) => void;
+  getHelperText?: (value: string) => string | undefined;
+}
+
 export interface InputFieldProps extends FieldProps {
   type?: TextInputTypes;
   placeholder?: string;

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -89,9 +89,12 @@ export const vipValidationSchema = (
   values: ClusterConfigurationValues,
   initialValue?: string,
 ) =>
-  requiredOnceSet(initialValue)
-    .concat(vipRangeValidationSchema(hostSubnets, values))
-    .concat(vipUniqueValidationSchema(hostSubnets, values));
+  Yup.mixed().when('vipDhcpAllocation', {
+    is: (value) => !value,
+    then: requiredOnceSet(initialValue)
+      .concat(vipRangeValidationSchema(hostSubnets, values))
+      .concat(vipUniqueValidationSchema(hostSubnets, values)),
+  });
 
 export const ipBlockValidationSchema = Yup.string()
   .required('A value is required.')


### PR DESCRIPTION
Just a simple switch to enable VIP DHCP allocation

DHCP off - user has to specify api and ingress VIP
![Screenshot from 2020-08-21 12-53-55](https://user-images.githubusercontent.com/2078045/90883134-89dc8780-e3ad-11ea-85ae-73ab701ccb81.png)

DHCP on - api and ingress VIP fields are hidden
![Screenshot from 2020-08-21 12-53-44](https://user-images.githubusercontent.com/2078045/90883136-8b0db480-e3ad-11ea-816e-20096f11a3bf.png)

JIRA https://issues.redhat.com/browse/MGMT-1751

@andybraren I guess we will want to add some help text and possibly rename the switch too.
