### PR TITLE
Adjust DNS-related field text

### DIFF
--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -59,9 +59,8 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
 
   const baseDnsHelperText = (
     <>
-      The base domain of the cluster. All DNS records must be sub-domains of this base and include
-      the cluster name. This cannot be changed after cluster installation. The full cluster address
-      will be:{' '}
+      All DNS records must be subdomains of this base and include the cluster name. This cannot be
+      changed after cluster installation. The full cluster address will be: <br />
       <strong>
         {clusterName || '[Cluster Name]'}.{baseDnsDomain || '[example.com]'}
       </strong>
@@ -79,14 +78,14 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       {!!managedDomains.length && (
         <CheckboxField
           name="useRedHatDnsService"
-          label="Use a temporary DNS domain from Red Hat"
-          helperText="A base DNS domain will be provided by Red Hat's DNS service. Because the cluster's DNS can't be changed after cluster installation, this should only be used for temporary, non-production clusters."
+          label="Use a temporary 60-day domain"
+          helperText="A base domain will be provided for temporary, non-production clusters."
           onChange={toggleRedHatDnsService}
         />
       )}
       {values.useRedHatDnsService ? (
         <SelectField
-          label="Base DNS Domain"
+          label="Base Domain"
           name="baseDnsDomain"
           helperText={baseDnsHelperText}
           options={managedDomains.map((d) => ({
@@ -97,7 +96,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         />
       ) : (
         <InputField
-          label="Base DNS Domain"
+          label="Base Domain"
           name="baseDnsDomain"
           helperText={baseDnsHelperText}
           placeholder="example.com"


### PR DESCRIPTION
Adjusts the wording of the DNS-related fields:

- Makes it clear that the temporary domain is only good for ~60 days (discussed in #97, FYI @ohadlevy)
- Renames `Base DNS Domain` to just `Base Domain` because that's how the [4.5 documentation](https://docs.openshift.com/container-platform/4.5/installing/installing_bare_metal/installing-bare-metal.html) refers to it and @nirfarkas' [fresh eyes](https://github.com/mareklibra/facet-lib/pull/97#issuecomment-664795981) are a treasure
- Attempts to add a line break so that the full address is always on a new line (let me know if I did it wrong)
- Less text to read which is good

## Before

![image](https://user-images.githubusercontent.com/9122899/91520745-10202e80-e8c4-11ea-849a-1667fab0631a.png)

## After

![image](https://user-images.githubusercontent.com/9122899/91520682-e23aea00-e8c3-11ea-8375-7f09c212a7b7.png)
