### PR TITLE
Log facet-lib version

### DIFF
--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,3 +1,4 @@
+import * as packageJson from '../../package.json';
 import { ClusterCreateParams, Cluster, Host, HostRoleUpdateParams } from '../api/types';
 import { ValidationsInfo, Validation } from '../types/hosts';
 
@@ -125,3 +126,5 @@ export const HOST_VALIDATION_LABELS: { [key in Validation['id']]: string } = {
   'belongs-to-machine-cidr': 'Belongs to machine CIDR',
   'role-defined': 'Role',
 };
+
+export const getFacetLibVersion = () => packageJson.version;

--- a/src/hacks.ts
+++ b/src/hacks.ts
@@ -1,6 +1,9 @@
 import React from 'react';
+import { getFacetLibVersion } from './config';
 
 // TODO(jtomasek): Stop using this once https://github.com/developit/microbundle/issues/564#issuecomment-593146626
 // is fixed, use `microbundle --jsxFragment React.Fragment` instead.
 // Workaround for TS17016
 window['Fragment'] = React.Fragment;
+
+console.info('Facet-lib version: ', getFacetLibVersion());


### PR DESCRIPTION
In addition to this, we can add facet-lib version to the OCM About modal dialog.