### PR TITLE
Fix machine cidr dhcp

### DIFF
--- a/src/components/clusterConfiguration/BasicNetworkFields.tsx
+++ b/src/components/clusterConfiguration/BasicNetworkFields.tsx
@@ -49,6 +49,8 @@ type BasicNetworkFieldsProps = {
 
 const BasicNetworkFields: React.FC<BasicNetworkFieldsProps> = ({ cluster, hostSubnets }) => {
   const { validateField, values, setFieldValue } = useFormikContext<ClusterConfigurationValues>();
+
+  // Automatically set hostSubnet if hostSubnets become available
   React.useEffect(() => {
     if (
       !values.hostSubnet ||
@@ -89,8 +91,10 @@ const BasicNetworkFields: React.FC<BasicNetworkFieldsProps> = ({ cluster, hostSu
             : undefined;
         }}
         onChange={() => {
-          validateField('ingressVip');
-          validateField('apiVip');
+          if (!values.vipDhcpAllocation) {
+            validateField('ingressVip');
+            validateField('apiVip');
+          }
         }}
         isRequired
       />


### PR DESCRIPTION
Depends on https://github.com/mareklibra/facet-lib/pull/196

    - if DHCP enabled, populate hostSubnet initial value from machine-network-cidr
    - display requestedHostname in list of hostnames in available subnets select
    - don't populate vip initial values if DHCP is on. When user disables DHCP
      they need to set the VIPs manually