### PR TITLE
MGMT-1962 Accept network CIDR as noProxy

### DIFF
--- a/src/components/clusterConfiguration/ProxyFields.tsx
+++ b/src/components/clusterConfiguration/ProxyFields.tsx
@@ -17,6 +17,13 @@ const ProxyFields: React.FC = () => {
     }
   };
 
+  /* TODO(mlibra): Uncomment after: https://bugzilla.redhat.com/show_bug.cgi?id=1877486
+  const noProxyHelperText =
+    'A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying. Preface a domain with . to include all subdomains of that domain. Use * to bypass proxy for all destinations.';
+    */
+  const noProxyHelperText =
+    'A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying. Preface a domain with . to include all subdomains of that domain.';
+
   // https://docs.openshift.com/container-platform/4.4/networking/enable-cluster-wide-proxy.html
   return (
     <>
@@ -56,7 +63,7 @@ const ProxyFields: React.FC = () => {
             label="No Proxy domains"
             name="noProxy"
             placeholder="one.domain.com,second.domain.com"
-            helperText="A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs to exclude proxying. Preface a domain with . to include all subdomains of that domain. Use * to bypass proxy for all destinations."
+            helperText={noProxyHelperText}
           />
         </>
       )}

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -202,6 +202,11 @@ export const noProxyValidationSchema = Yup.string().test(
         return true;
       }
 
+      // network CIDR
+      if (item.match(IP_ADDRESS_BLOCK_REGEX)) {
+        return true;
+      }
+
       return false;
     });
   },

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -178,15 +178,17 @@ export const noProxyValidationSchema = Yup.string().test(
       return true;
     }
 
+    // https://docs.openshift.com/container-platform/4.5/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-configure-proxy_installing-restricted-networks-bare-metal
     // A comma-separated list of destination domain names, domains, IP addresses or other network CIDRs
     // to exclude proxying. Preface a domain with . to include all subdomains of that domain.
     // Use * to bypass proxy for all destinations."
     const items = value.split(',');
     return items.every((item) => {
+      /* TODO(mlibra): Uncomment after: https://bugzilla.redhat.com/show_bug.cgi?id=1877486
       if (item === '*') {
         return true;
       }
-
+      */
       let domain = item;
       if (item.charAt(0) === '.') {
         domain = item.substr(1);


### PR DESCRIPTION
Based on: https://docs.openshift.com/container-platform/4.5/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-configure-proxy_installing-restricted-networks-bare-metal

In addition, a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1877486 is provided.