### PR TITLE
Change clusters list title

### DIFF
--- a/src/components/clusters/Clusters.tsx
+++ b/src/components/clusters/Clusters.tsx
@@ -97,7 +97,7 @@ const Clusters: React.FC<ClustersProps> = ({ history }) => {
         <>
           <PageSection variant={PageSectionVariants.light}>
             <TextContent>
-              <Text component="h1">Managed Clusters</Text>
+              <Text component="h1">Assisted Bare Metal Clusters</Text>
             </TextContent>
           </PageSection>
           <PageSection variant={PageSectionVariants.light} isMain>


### PR DESCRIPTION
The current title of `Managed Clusters` is easy to confuse with OCM's regular `Clusters` page, which could make it seem like the other clusters "disappeared" from the user's list.

This PR changes the title to `Assisted Bare Metal Clusters` to more clearly distinguish our list from the regular/full one (until we can be fully integrated 🙂).

## Current

![image](https://user-images.githubusercontent.com/9122899/93399445-9be60480-f84b-11ea-8f69-d90ac76d451a.png)

## New

![image](https://user-images.githubusercontent.com/9122899/93399500-b3bd8880-f84b-11ea-9635-a18440e3d4b7.png)
