### PR TITLE
MGMT-1917 Make pull secret editable in OCM

### DIFF
--- a/src/components/clusters/NewClusterPage.tsx
+++ b/src/components/clusters/NewClusterPage.tsx
@@ -10,6 +10,7 @@ import {
   TextContent,
   Text,
   ButtonVariant,
+  ExpandableSection,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import PageSection from '../ui/PageSection';
@@ -46,8 +47,46 @@ const pullSecretHelperText = (
   </>
 );
 
-type NewClusterFormProps = RouteComponentProps & {
+type PullSecretProps = {
   pullSecret?: string;
+};
+
+type NewClusterFormProps = RouteComponentProps & PullSecretProps;
+
+const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
+  // Fetched pull secret will never change - see LoadingState in NewCluster
+  const [isExpanded, setExpanded] = React.useState(!pullSecret);
+  const textArea = (
+    <TextAreaField
+      name="pullSecret"
+      label="Pull Secret"
+      getErrorText={(error) => (
+        <>
+          {error} {pullSecretHelperText}
+        </>
+      )}
+      helperText={pullSecretHelperText}
+      isRequired
+    />
+  );
+
+  if (ocmClient) {
+    return (
+      <ExpandableSection
+        toggleText={
+          isExpanded
+            ? 'Collapse pull secret'
+            : 'Pull secret retrieved automatically. Expand to edit.'
+        }
+        onToggle={() => setExpanded(!isExpanded)}
+        isExpanded={isExpanded}
+      >
+        {textArea}
+      </ExpandableSection>
+    );
+  }
+
+  return textArea;
 };
 
 const NewClusterForm: React.FC<NewClusterFormProps> = ({ history, pullSecret = '' }) => {
@@ -95,8 +134,6 @@ const NewClusterForm: React.FC<NewClusterFormProps> = ({ history, pullSecret = '
     }
   };
 
-  const isPullSecretHidden = ocmClient && pullSecret;
-
   return (
     <>
       <ClusterBreadcrumbs clusterName="New cluster" />
@@ -127,19 +164,7 @@ const NewClusterForm: React.FC<NewClusterFormProps> = ({ history, pullSecret = '
                       options={OPENSHIFT_VERSION_OPTIONS}
                       isRequired
                     />
-                    {!isPullSecretHidden && (
-                      <TextAreaField
-                        name="pullSecret"
-                        label="Pull Secret"
-                        getErrorText={(error) => (
-                          <>
-                            {error} {pullSecretHelperText}
-                          </>
-                        )}
-                        helperText={pullSecretHelperText}
-                        isRequired
-                      />
-                    )}
+                    <PullSecret pullSecret={pullSecret} />
                   </Form>
                 </GridItem>
               </Grid>

--- a/src/components/clusters/NewClusterPage.tsx
+++ b/src/components/clusters/NewClusterPage.tsx
@@ -10,9 +10,7 @@ import {
   TextContent,
   Text,
   ButtonVariant,
-  ExpandableSection,
 } from '@patternfly/react-core';
-import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import PageSection from '../ui/PageSection';
 import { ToolbarButton } from '../ui/Toolbar';
 import ClusterToolbar from './ClusterToolbar';
@@ -20,74 +18,18 @@ import AlertsSection from '../ui/AlertsSection';
 import { handleApiError, getErrorMessage } from '../../api/utils';
 import { AlertsContext, AlertsContextProvider } from '../AlertsContextProvider';
 import ClusterBreadcrumbs from './ClusterBreadcrumbs';
-import {
-  routeBasePath,
-  OPENSHIFT_VERSION_OPTIONS,
-  CLUSTER_MANAGER_SITE_LINK,
-} from '../../config/constants';
+import { routeBasePath, OPENSHIFT_VERSION_OPTIONS } from '../../config/constants';
 import { getClusters, postCluster } from '../../api/clusters';
 import { ClusterCreateParams } from '../../api/types';
 import { nameValidationSchema, validJSONSchema } from '../ui/formik/validationSchemas';
 import { ocmClient } from '../../api/axiosClient';
 import InputField from '../ui/formik/InputField';
 import SelectField from '../ui/formik/SelectField';
-import TextAreaField from '../ui/formik/TextAreaField';
 import LoadingState from '../ui/uiState/LoadingState';
 import { captureException } from '../../sentry';
-
-const pullSecretHelperText = (
-  <>
-    Your Red Hat account's pull secret will be used by default. The pull secret of an account can be
-    found on{' '}
-    {
-      <a href={CLUSTER_MANAGER_SITE_LINK} target="_blank" rel="noopener noreferrer">
-        this page <ExternalLinkAltIcon />
-      </a>
-    }
-  </>
-);
-
-type PullSecretProps = {
-  pullSecret?: string;
-};
+import PullSecret, { PullSecretProps } from './PullSecret';
 
 type NewClusterFormProps = RouteComponentProps & PullSecretProps;
-
-const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
-  // Fetched pull secret will never change - see LoadingState in NewCluster
-  const [isExpanded, setExpanded] = React.useState(!pullSecret);
-  const textArea = (
-    <TextAreaField
-      name="pullSecret"
-      label="Pull Secret"
-      getErrorText={(error) => (
-        <>
-          {error} {pullSecretHelperText}
-        </>
-      )}
-      helperText={pullSecretHelperText}
-      isRequired
-    />
-  );
-
-  if (ocmClient) {
-    return (
-      <ExpandableSection
-        toggleText={
-          isExpanded
-            ? 'Collapse pull secret'
-            : 'Pull secret retrieved automatically. Expand to edit.'
-        }
-        onToggle={() => setExpanded(!isExpanded)}
-        isExpanded={isExpanded}
-      >
-        {textArea}
-      </ExpandableSection>
-    );
-  }
-
-  return textArea;
-};
 
 const NewClusterForm: React.FC<NewClusterFormProps> = ({ history, pullSecret = '' }) => {
   const { addAlert, clearAlerts } = React.useContext(AlertsContext);

--- a/src/components/clusters/PullSecret.tsx
+++ b/src/components/clusters/PullSecret.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import { Checkbox, Popover } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
-import { ocmClient } from '../../api';
+import { ClusterCreateParams, ocmClient } from '../../api';
 import { CLUSTER_MANAGER_SITE_LINK, PULL_SECRET_INFO_LINK } from '../../config';
 import { TextAreaField } from '../ui';
+import { useFormikContext } from 'formik';
 
 export type PullSecretProps = {
   pullSecret?: string;
@@ -47,6 +48,8 @@ const PullSecretInfo = () => (
 const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
   // Fetched pull secret will never change - see LoadingState in NewCluster
   const [isExpanded, setExpanded] = React.useState(!pullSecret);
+  const { setFieldValue } = useFormikContext<ClusterCreateParams>();
+
   const textArea = (
     <TextAreaField
       name="pullSecret"
@@ -63,6 +66,14 @@ const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
   );
 
   if (ocmClient) {
+    const onCheckboxChange = () => {
+      if (isExpanded) {
+        // about to collapse, reset to original value
+        setFieldValue('pullSecret', pullSecret);
+      }
+      setExpanded(!isExpanded);
+    };
+
     return (
       <>
         <Checkbox
@@ -74,7 +85,7 @@ const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
           }
           aria-label="customize pull secret"
           isChecked={isExpanded}
-          onChange={() => setExpanded(!isExpanded)}
+          onChange={onCheckboxChange}
         />
         {isExpanded && textArea}
       </>

--- a/src/components/clusters/PullSecret.tsx
+++ b/src/components/clusters/PullSecret.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Checkbox, Popover } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { ocmClient } from '../../api';
+import { CLUSTER_MANAGER_SITE_LINK, PULL_SECRET_INFO_LINK } from '../../config';
+import { TextAreaField } from '../ui';
+
+export type PullSecretProps = {
+  pullSecret?: string;
+};
+
+const ClusterManagerSiteLink = ({ text = 'OpenShiftCluster Manager' }: { text?: string }) => (
+  <a href={CLUSTER_MANAGER_SITE_LINK} target="_blank" rel="noopener noreferrer">
+    {text} <ExternalLinkAltIcon />
+  </a>
+);
+
+const pullSecretHelperText = ocmClient ? (
+  <>
+    Your Red Hat account's pull secret is used by default.&nbsp;
+    <a href={PULL_SECRET_INFO_LINK} target="_blank" rel="noopener noreferrer">
+      Learn more about pull secrets <ExternalLinkAltIcon />
+    </a>
+  </>
+) : (
+  <>
+    A Red Hat account's pull secret can be found in &nbsp;
+    <ClusterManagerSiteLink />
+  </>
+);
+
+const PullSecretInfo = () => (
+  <Popover
+    position="top"
+    bodyContent={
+      <>
+        Pull secrets are used to download OpenShift Container Platform components and connect
+        clusters to a Red Hat account. Pull secrets can be found in&nbsp;
+        <ClusterManagerSiteLink />
+      </>
+    }
+  >
+    <OutlinedQuestionCircleIcon />
+  </Popover>
+);
+
+const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
+  // Fetched pull secret will never change - see LoadingState in NewCluster
+  const [isExpanded, setExpanded] = React.useState(!pullSecret);
+  const textArea = (
+    <TextAreaField
+      name="pullSecret"
+      label="Pull Secret"
+      labelIcon={ocmClient ? undefined : <PullSecretInfo />}
+      getErrorText={(error) => (
+        <>
+          {error} {pullSecretHelperText}
+        </>
+      )}
+      helperText={pullSecretHelperText}
+      isRequired
+    />
+  );
+
+  if (ocmClient) {
+    return (
+      <>
+        <Checkbox
+          id="checkbox-pull-secret"
+          label={
+            <span onClick={(event) => event.preventDefault()}>
+              Customize pull secret <PullSecretInfo />
+            </span>
+          }
+          aria-label="customize pull secret"
+          isChecked={isExpanded}
+          onChange={() => setExpanded(!isExpanded)}
+        />
+        {isExpanded && textArea}
+      </>
+    );
+  }
+
+  return textArea;
+};
+
+export default PullSecret;

--- a/src/components/clusters/PullSecret.tsx
+++ b/src/components/clusters/PullSecret.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Checkbox, Popover } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { Checkbox } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { ClusterCreateParams, ocmClient } from '../../api';
 import { CLUSTER_MANAGER_SITE_LINK, PULL_SECRET_INFO_LINK } from '../../config';
 import { TextAreaField } from '../ui';
 import { useFormikContext } from 'formik';
+import PopoverIcon from '../ui/PopoverIcon';
 
 export type PullSecretProps = {
   pullSecret?: string;
@@ -35,8 +36,7 @@ const pullSecretHelperText = ocmClient ? (
 );
 
 const PullSecretInfo = () => (
-  <Popover
-    position="top"
+  <PopoverIcon
     bodyContent={
       <>
         Pull secrets are used to download OpenShift Container Platform components and connect
@@ -51,11 +51,7 @@ const PullSecretInfo = () => (
         )}
       </>
     }
-  >
-    <button onClick={(e) => e.preventDefault()} className="pf-c-form__group-label-help">
-      <OutlinedQuestionCircleIcon noVerticalAlign />
-    </button>
-  </Popover>
+  />
 );
 
 const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {

--- a/src/components/clusters/PullSecret.tsx
+++ b/src/components/clusters/PullSecret.tsx
@@ -10,18 +10,22 @@ export type PullSecretProps = {
   pullSecret?: string;
 };
 
-const ClusterManagerSiteLink = ({ text = 'OpenShiftCluster Manager' }: { text?: string }) => (
+const ClusterManagerSiteLink = () => (
   <a href={CLUSTER_MANAGER_SITE_LINK} target="_blank" rel="noopener noreferrer">
-    {text} <ExternalLinkAltIcon />
+    OpenShift Cluster Manager <ExternalLinkAltIcon />
+  </a>
+);
+
+const PullSecretInfoLink = () => (
+  <a href={PULL_SECRET_INFO_LINK} target="_blank" rel="noopener noreferrer">
+    Learn more about pull secrets <ExternalLinkAltIcon />.
   </a>
 );
 
 const pullSecretHelperText = ocmClient ? (
   <>
     Your Red Hat account's pull secret is used by default.&nbsp;
-    <a href={PULL_SECRET_INFO_LINK} target="_blank" rel="noopener noreferrer">
-      Learn more about pull secrets <ExternalLinkAltIcon />
-    </a>
+    <PullSecretInfoLink />
   </>
 ) : (
   <>
@@ -36,12 +40,21 @@ const PullSecretInfo = () => (
     bodyContent={
       <>
         Pull secrets are used to download OpenShift Container Platform components and connect
-        clusters to a Red Hat account. Pull secrets can be found in&nbsp;
-        <ClusterManagerSiteLink />
+        clusters to a Red Hat account.&nbsp;
+        {ocmClient ? (
+          <PullSecretInfoLink />
+        ) : (
+          <>
+            Pull secrets can be found in&nbsp;
+            <ClusterManagerSiteLink />
+          </>
+        )}
       </>
     }
   >
-    <OutlinedQuestionCircleIcon />
+    <button onClick={(e) => e.preventDefault()} className="pf-c-form__group-label-help">
+      <OutlinedQuestionCircleIcon noVerticalAlign />
+    </button>
   </Popover>
 );
 
@@ -78,14 +91,15 @@ const PullSecret: React.FC<PullSecretProps> = ({ pullSecret }) => {
       <>
         <Checkbox
           id="checkbox-pull-secret"
-          label={
-            <span onClick={(event) => event.preventDefault()}>
-              Customize pull secret <PullSecretInfo />
-            </span>
-          }
-          aria-label="customize pull secret"
+          className="pf-u-display-inline-flex"
+          aria-label="edit pull secret"
           isChecked={isExpanded}
           onChange={onCheckboxChange}
+          label={
+            <>
+              Edit pull secret <PullSecretInfo />
+            </>
+          }
         />
         {isExpanded && textArea}
       </>

--- a/src/components/ui/PopoverIcon.tsx
+++ b/src/components/ui/PopoverIcon.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Popover } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { PopoverProps } from '@patternfly/react-core/dist/js/components/Popover/Popover';
+import { SVGIconProps } from '@patternfly/react-icons/dist/js/createIcon';
+
+type PopoverIconProps = PopoverProps & {
+  IconComponent?: React.ComponentClass<SVGIconProps>;
+};
+
+const PopoverIcon: React.FC<PopoverIconProps> = ({
+  IconComponent = OutlinedQuestionCircleIcon,
+  ...props
+}) => (
+  <Popover {...props}>
+    <button onClick={(e) => e.preventDefault()} className="pf-c-form__group-label-help">
+      <IconComponent noVerticalAlign />
+    </button>
+  </Popover>
+);
+
+export default PopoverIcon;

--- a/src/components/ui/formik/InputField.tsx
+++ b/src/components/ui/formik/InputField.tsx
@@ -7,7 +7,7 @@ import HelperText from './HelperText';
 
 const InputField: React.FC<InputFieldProps> = React.forwardRef(
   (
-    { label, helperText, isRequired, onChange, validate, idPostfix, ...props },
+    { label, labelIcon, helperText, isRequired, onChange, validate, idPostfix, ...props },
     ref: React.Ref<HTMLInputElement>,
   ) => {
     const [field, { touched, error }] = useField({ name: props.name, validate });
@@ -28,6 +28,7 @@ const InputField: React.FC<InputFieldProps> = React.forwardRef(
         helperTextInvalid={errorMessage}
         validated={isValid ? 'default' : 'error'}
         isRequired={isRequired}
+        labelIcon={labelIcon}
       >
         <TextInput
           {...field}

--- a/src/components/ui/formik/SelectField.tsx
+++ b/src/components/ui/formik/SelectField.tsx
@@ -13,6 +13,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
   onChange,
   getHelperText,
   idPostfix,
+  labelIcon,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -30,6 +31,7 @@ const SelectField: React.FC<SelectFieldProps> = ({
       helperTextInvalid={errorMessage}
       validated={isValid ? 'default' : 'error'}
       isRequired={isRequired}
+      labelIcon={labelIcon}
     >
       <FormSelect
         {...field}

--- a/src/components/ui/formik/SwitchField.tsx
+++ b/src/components/ui/formik/SwitchField.tsx
@@ -12,6 +12,7 @@ const SwitchField: React.FC<SwitchFieldProps> = ({
   onChange,
   getHelperText,
   idPostfix,
+  labelIcon,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -28,6 +29,7 @@ const SwitchField: React.FC<SwitchFieldProps> = ({
       helperTextInvalid={errorMessage}
       validated={isValid ? 'default' : 'error'}
       isRequired={isRequired}
+      labelIcon={labelIcon}
     >
       <Switch
         {...field}

--- a/src/components/ui/formik/TextAreaField.tsx
+++ b/src/components/ui/formik/TextAreaField.tsx
@@ -12,6 +12,7 @@ const TextAreaField: React.FC<TextAreaProps> = ({
   isRequired,
   children,
   idPostfix,
+  labelIcon,
   ...props
 }) => {
   const [field, { touched, error }] = useField(props.name);
@@ -49,6 +50,7 @@ const TextAreaField: React.FC<TextAreaProps> = ({
       }
       validated={isValid ? 'default' : 'error'}
       isRequired={isRequired}
+      labelIcon={labelIcon}
     >
       {children}
       <TextArea

--- a/src/components/ui/formik/UploadField.tsx
+++ b/src/components/ui/formik/UploadField.tsx
@@ -7,6 +7,7 @@ import HelperText from './HelperText';
 
 const UploadField: React.FC<TextAreaProps> = ({
   label,
+  labelIcon,
   helperText,
   getErrorText,
   isRequired,
@@ -53,6 +54,7 @@ const UploadField: React.FC<TextAreaProps> = ({
       }
       validated={isValid ? 'default' : 'error'}
       isRequired={isRequired}
+      labelIcon={labelIcon}
     >
       {children}
       <FileUpload

--- a/src/components/ui/formik/types.ts
+++ b/src/components/ui/formik/types.ts
@@ -4,6 +4,7 @@ import { FieldValidator } from 'formik';
 export interface FieldProps {
   name: string;
   label?: string;
+  labelIcon?: React.ReactElement;
   helperText?: React.ReactNode;
   isRequired?: boolean;
   style?: React.CSSProperties;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -19,6 +19,7 @@ export const DEFAULT_OPENSHIFT_VERSION: OpenshiftVersionOptionType['value'] =
   OPENSHIFT_VERSION_OPTIONS[0].value;
 
 export const CLUSTER_MANAGER_SITE_LINK = 'https://cloud.redhat.com/openshift/install/pull-secret';
+export const PULL_SECRET_INFO_LINK = CLUSTER_MANAGER_SITE_LINK;
 
 export const FEEDBACK_FORM_LINK =
   'https://docs.google.com/forms/d/e/1FAIpQLSfg9M8wRW4m_HkWeAl6KpB5dTcMu8iI3iJ29GlLfZpF2hnjng/viewform';


### PR DESCRIPTION
With this patch, the OCM user can edit pull-secret. Since this is expected to be a rare case, the field is not visible by default. Prior this patch, this field was hidden in OCM.

The pull-secret is not visible by default (is collapsed) but the user canexpand an area to edit it.
If pull-secret automatic fetch fails, the area is expanded by default (plus error message is shown).

Outside of the OCM, the pull-secret filed is always rendered.