### PR TITLE
Fix error message in Sentry

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -8,21 +8,21 @@ export const handleApiError = <T>(error: AxiosError<T>, onError?: OnError) => {
   if (Axios.isCancel(error)) {
     captureException(error, 'Request canceled');
   } else {
-    let message = `Error config: ${error.config}\n`;
+    let message = `Error config: ${JSON.stringify(error.config, null, 2)}\n`;
     if (error.response) {
       // The request was made and the server responded with a status code
       // that falls out of the range of 2xx
-      message += `Response data: ${error.response.data}\n`;
+      message += `Response data: ${JSON.stringify(error.response.data, null, 2)}\n`;
       message += `Response status: ${error.response.status}\n`;
-      message += `Response headers: ${error.response.headers}`;
+      message += `Response headers: ${JSON.stringify(error.response.headers, null, 2)}`;
     } else if (error.request) {
       // The request was made but no response was received
       // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
       // http.ClientRequest in node.js
-      message += `Request: ${error.request}`;
+      message += `Request: ${JSON.stringify(error.request, null, 2)}`;
     } else {
       // Something happened in setting up the request that triggered an Error
-      message += `Error: ${error.message}`;
+      message += `Error: ${JSON.stringify(error.message, null, 2)}`;
     }
     captureException(error, message);
     if (onError) return onError(error);


### PR DESCRIPTION
This change ensures that objects in error message get stringified
to ensure correct formating in Sentry UI

This is how the messages look without this change:
![image](https://user-images.githubusercontent.com/1121740/94021993-ec61e280-fdb4-11ea-99b9-7d1c170f2556.png)
