### PR TITLE
OCPBUGSM-17672 Hotfix HostsTable height after collapsing detail

### DIFF
--- a/src/components/hosts/HostsTable.css
+++ b/src/components/hosts/HostsTable.css
@@ -10,3 +10,6 @@
   font-size: var(--pf-c-table-cell--FontSize);
 }
 
+.hosts-table {
+  height: 1rem; /* Workaround for: https://bugzilla.redhat.com/show_bug.cgi?id=1879378 in FF; The actual table height will be recalculated accordingly. */
+}


### PR DESCRIPTION
The HostsTable height is not recalculated after collapsing a row which is causing "blowing" all the row heights.

The issue was observed in Firefox but not in Chrome.

I will try to reproduce that without AI context and report to Patternfly.