### PR TITLE
MGMT-1822 Make Cluster list filters persistent

### DIFF
--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -69,8 +69,12 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
   React.useEffect(() => {
     const marshalled = window.sessionStorage.getItem(STORAGE_KEY_CLUSTERS_FILTER);
     if (marshalled) {
-      const parsed = JSON.parse(marshalled);
-      setFilters(parsed);
+      try {
+        const parsed = JSON.parse(marshalled);
+        setFilters(parsed);
+      } catch (e) {
+        console.info('Failed to restore clusters filter: ', e);
+      }
     }
   }, []);
 

--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -23,6 +23,8 @@ import ClustersFilterToolbar, { ClusterFiltersType } from './ClustersFilterToolb
 
 const rowKey = ({ rowData }: ExtraParamsType) => rowData?.props.id;
 
+const STORAGE_KEY_CLUSTERS_FILTER = 'assisted-installer-cluster-list-filters';
+
 interface ClustersTableProps {
   rows: ClusterTableRows;
   deleteCluster: (id: string) => void;
@@ -63,6 +65,18 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
   const [filters, setFilters] = React.useState<ClusterFiltersType>({
     status: [],
   });
+
+  React.useEffect(() => {
+    const marshalled = window.sessionStorage.getItem(STORAGE_KEY_CLUSTERS_FILTER);
+    if (marshalled) {
+      const parsed = JSON.parse(marshalled);
+      setFilters(parsed);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    window.sessionStorage.setItem(STORAGE_KEY_CLUSTERS_FILTER, JSON.stringify(filters));
+  }, [filters]);
 
   const actionResolver: IActionsResolver = React.useCallback(
     (rowData) => [

--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -71,7 +71,9 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
     if (marshalled) {
       try {
         const parsed = JSON.parse(marshalled);
-        setFilters(parsed);
+        parsed.filters && setFilters(parsed.filters);
+        parsed.sortBy && setSortBy(parsed.sortBy);
+        parsed.searchName && setSearchName(parsed.searchName);
       } catch (e) {
         console.info('Failed to restore clusters filter: ', e);
       }
@@ -79,8 +81,11 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
   }, []);
 
   React.useEffect(() => {
-    window.sessionStorage.setItem(STORAGE_KEY_CLUSTERS_FILTER, JSON.stringify(filters));
-  }, [filters]);
+    window.sessionStorage.setItem(
+      STORAGE_KEY_CLUSTERS_FILTER,
+      JSON.stringify({ filters, sortBy, searchName }),
+    );
+  }, [filters, sortBy, searchName]);
 
   const actionResolver: IActionsResolver = React.useCallback(
     (rowData) => [


### PR DESCRIPTION
The state of filters on the Cluster list page stays persistent
unless the application is opened in a new tab.

The state survives page refresh (F5) or navigatino within the application.