### PR TITLE
Don't display pending validations in the host status popover

### DIFF
--- a/src/components/hosts/HostValidationGroups.tsx
+++ b/src/components/hosts/HostValidationGroups.tsx
@@ -30,7 +30,7 @@ const HostValidationGroups: React.FC<HostValidationGroupsProps> = ({ validations
           if (pendingValidations.length) {
             return (
               <>
-                Pending <PendingIcon />
+                Pending input <PendingIcon />
               </>
             );
           } else if (failedValidations.length) {
@@ -56,11 +56,13 @@ const HostValidationGroups: React.FC<HostValidationGroupsProps> = ({ validations
               <LevelItem>{getValidationGroupState()}</LevelItem>
             </Level>
             <AlertGroup>
-              <ValidationGroupAlert
-                variant={AlertVariant.info}
-                title="Pending validations:"
-                validations={pendingValidations}
-              />
+              {!failedValidations.length && ( // display pending validations only if there are no failing validations
+                <ValidationGroupAlert
+                  variant={AlertVariant.info}
+                  title="Pending validations:"
+                  validations={pendingValidations}
+                />
+              )}
               <ValidationGroupAlert
                 variant={AlertVariant.warning}
                 title="Failed validations:"


### PR DESCRIPTION
Display only failing validations in host status popover. Display pending
validations only if there are no failing ones (should not really ever happen).
The reason for this is that pending validations are always pending due to
another validation being failed.

The validation group status is 'Pending input' if there are any pending validations.
This is to better communicate that validations are failing due to us waiting for
user input.