### PR TITLE
Fix strict error sentry logging for canceled requests

### DIFF
--- a/src/api/utils.ts
+++ b/src/api/utils.ts
@@ -1,3 +1,4 @@
+import { Severity } from '@sentry/browser';
 import Axios, { AxiosError } from 'axios';
 import _ from 'lodash';
 import { captureException } from '../sentry';
@@ -6,7 +7,7 @@ type OnError = <T>(arg0: AxiosError<T>) => void;
 
 export const handleApiError = <T>(error: AxiosError<T>, onError?: OnError) => {
   if (Axios.isCancel(error)) {
-    captureException(error, 'Request canceled');
+    captureException(error, 'Request canceled', Severity.Info);
   } else {
     let message = `Error config: ${JSON.stringify(error.config, null, 2)}\n`;
     if (error.response) {

--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -99,7 +99,7 @@ const ClusterConfigurationForm: React.FC<ClusterConfigurationFormProps> = ({
         return formikActions.setFieldError('name', `Name "${values.name}" is already taken.`);
       }
     } catch (e) {
-      captureException('Failed to perform unique cluster name validation.', e);
+      captureException(e, 'Failed to perform unique cluster name validation.');
     }
 
     // update the cluster configuration

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,18 +1,18 @@
 import * as Sentry from '@sentry/browser';
 import { ocmClient } from './api/axiosClient';
 
-export enum SEVERITY {
-  ERROR = 'error',
-  WARN = 'warning',
-}
-
-// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-// @ts-ignore
-export const captureException = (error, message?: string, severity: SEVERITY = SEVERITY.ERROR) => {
+export const captureException = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: any,
+  message?: string,
+  severity: Sentry.Severity = Sentry.Severity.Error,
+) => {
   if (ocmClient) {
-    message && Sentry.captureMessage(message, SEVERITY[severity]);
+    message && Sentry.captureMessage(message, severity);
     Sentry.captureException(error);
   } else {
-    severity === SEVERITY.ERROR ? console.error(message, error) : console.warn(message, error);
+    severity === Sentry.Severity.Error
+      ? console.error(message, error)
+      : console.warn(message, error);
   }
 };


### PR DESCRIPTION
The event is falsely marked as an error since it is result of an user's action - clicking on Cancel during long-running task of generating an ISO image. So far we want to track these actions, so marking it by Info level only. 