### PR TITLE
Update API + new host/cluster statuses

### DIFF
--- a/src/api/swagger.yaml
+++ b/src/api/swagger.yaml
@@ -95,6 +95,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}:
     get:
@@ -138,6 +142,10 @@ paths:
             $ref: '#/definitions/error'
         500:
           description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
           schema:
             $ref: '#/definitions/error'
 
@@ -393,6 +401,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/downloads/files-presigned:
     get:
@@ -425,9 +437,15 @@ paths:
             ]
           required: true
         - in: query
+          name: logs_type
+          type: string
+          enum: ['host', 'controller', 'all']
+          required: false
+        - in: query
           name: host_id
           type: string
           format: uuid
+          required: false
       responses:
         200:
           description: Success.
@@ -550,6 +568,42 @@ paths:
             $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/install-config:
+    get:
+      tags:
+        - installer
+      summary: Get the cluster install config yaml
+      operationId: GetClusterInstallConfig
+      parameters:
+        - in: path
+          name: cluster_id
+          type: string
+          format: uuid
+          required: true
+      responses:
+        200:
+          description: Success.
+          schema:
+            type: string
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/error'
+        404:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        405:
+          description: Method Not Allowed.
+          schema:
+            $ref: '#/definitions/error'
+        500:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
     patch:
       tags:
         - installer
@@ -644,6 +698,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/actions/install:
     post:
@@ -708,6 +766,52 @@ paths:
           description: Success.
           schema:
             $ref: '#/definitions/cluster'
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/infra_error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/infra_error'
+        404:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        405:
+          description: Method Not Allowed.
+          schema:
+            $ref: '#/definitions/error'
+        409:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        500:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+
+  /clusters/{cluster_id}/actions/install_hosts:
+    post:
+      tags:
+        - installer
+      summary: Installs the OpenShift bare metal cluster.
+      operationId: InstallHosts
+      parameters:
+        - in: path
+          name: cluster_id
+          type: string
+          format: uuid
+          required: true
+      responses:
+        202:
+          description: Success.
+          schema:
+            $ref: '#/definitions/cluster'
+        400:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
         401:
           description: Unauthorized.
           schema:
@@ -827,6 +931,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/hosts:
     post:
@@ -880,6 +988,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
     get:
       tags:
@@ -918,6 +1030,10 @@ paths:
             $ref: '#/definitions/error'
         500:
           description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
           schema:
             $ref: '#/definitions/error'
 
@@ -1062,6 +1178,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/hosts/{host_id}/actions/enable:
     post:
@@ -1084,7 +1204,7 @@ paths:
         200:
           description: Success.
           schema:
-            $ref: '#/definitions/host'
+            $ref: '#/definitions/cluster'
         401:
           description: Unauthorized.
           schema:
@@ -1130,7 +1250,7 @@ paths:
         200:
           description: Success.
           schema:
-            $ref: '#/definitions/host'
+            $ref: '#/definitions/cluster'
         401:
           description: Unauthorized.
           schema:
@@ -1204,6 +1324,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
     post:
       tags:
@@ -1258,6 +1382,10 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/hosts/{host_id}/logs:
     post:
@@ -1266,6 +1394,7 @@ paths:
       security:
         - agentAuth: []
       summary: Agent API to upload logs.
+      deprecated: true
       operationId: UploadHostLogs
       consumes:
         - multipart/form-data
@@ -1296,6 +1425,14 @@ paths:
       responses:
         204:
           description: Success.
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/infra_error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/infra_error'
         404:
           description: Error.
           schema:
@@ -1304,11 +1441,16 @@ paths:
           description: Error.
           schema:
             $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
 
     get:
       tags:
         - installer
       summary: Download host logs
+      deprecated: true
       security:
         - userAuth: []
       operationId: DownloadHostLogs
@@ -1356,6 +1498,62 @@ paths:
             $ref: '#/definitions/error'
 
   /clusters/{cluster_id}/logs:
+    post:
+      tags:
+        - installer
+      security:
+        - agentAuth: []
+      summary: Agent API to upload logs.
+      operationId: UploadLogs
+      consumes:
+        - multipart/form-data
+      parameters:
+        - in: path
+          name: cluster_id
+          type: string
+          format: uuid
+          required: true
+        - in: formData
+          name: upfile
+          type: file
+          required: false
+          maxLength: 20971520 #20MB
+          description: The file to upload.
+          x-mimetype: application/zip
+        - in: query
+          name: logs_type
+          type: string
+          enum: ['host', 'controller']
+          required: true
+        - in: query
+          name: host_id
+          type: string
+          format: uuid
+          required: false
+      responses:
+        204:
+          description: Success.
+        401:
+          description: Unauthorized.
+          schema:
+            $ref: '#/definitions/infra_error'
+        403:
+          description: Forbidden.
+          schema:
+            $ref: '#/definitions/infra_error'
+        404:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        500:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        503:
+          description: Unavailable.
+          schema:
+            $ref: '#/definitions/error'
+
     get:
       tags:
         - installer
@@ -1371,6 +1569,16 @@ paths:
           type: string
           format: uuid
           required: true
+        - in: query
+          name: logs_type
+          type: string
+          enum: ['host', 'controller', 'all']
+          required: false
+        - in: query
+          name: host_id
+          type: string
+          format: uuid
+          required: false
       responses:
         200:
           description: Success.
@@ -1555,6 +1763,34 @@ paths:
           schema:
             $ref: '#/definitions/error'
 
+  /add_hosts_clusters:
+    post:
+      tags:
+        - installer
+      summary:
+        Creates a new OpenShift bare metal cluster definition for adding nodes to and existing OCP
+        cluster.
+      operationId: RegisterAddHostsCluster
+      parameters:
+        - in: body
+          name: new-add-hosts-cluster-params
+          required: true
+          schema:
+            $ref: '#/definitions/add-hosts-cluster-create-params'
+      responses:
+        201:
+          description: Success.
+          schema:
+            $ref: '#/definitions/cluster'
+        400:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+        500:
+          description: Error.
+          schema:
+            $ref: '#/definitions/error'
+
 definitions:
   list-managed-domains:
     type: array
@@ -1667,10 +1903,10 @@ definitions:
     properties:
       kind:
         type: string
-        enum: ['Host']
-        description:
-          Indicates the type of this object. Will be 'Host' if this is a complete object or
-          'HostLink' if it is just a link.
+        enum: ['Host', 'AddToExistingClusterHost']
+        description: |
+          Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link, or 
+          'AddToExistingClusterHost' for host being added to existing OCP cluster.
       id:
         type: string
         format: uuid
@@ -1701,6 +1937,7 @@ definitions:
           - installed
           - error
           - resetting
+          - added-to-existing-cluster
       status_info:
         type: string
         x-go-custom-tag: gorm:"type:varchar(2048)"
@@ -1796,6 +2033,7 @@ definitions:
       - free-network-addresses
       - reset-installation
       - dhcp-lease-allocate
+      - api-vip-connectivity-check
 
   step:
     type: object
@@ -1925,7 +2163,7 @@ definitions:
         type: boolean
         description: Indicate if VIP DHCP allocation mode is enabled.
         x-nullable: true
-        default: false
+        default: true
       http_proxy:
         type: string
         description: |
@@ -2062,6 +2300,29 @@ definitions:
             hostname:
               type: string
 
+  add-hosts-cluster-create-params:
+    type: object
+    required:
+      - id
+      - name
+      - api_vip_dnsname
+      - openshift_version
+    properties:
+      id:
+        type: string
+        format: uuid
+        description: Unique identifier of the object.
+      name:
+        type: string
+        description: Name of the OpenShift cluster.
+      api_vip_dnsname:
+        type: string
+        description: api vip domain.
+      openshift_version:
+        type: string
+        enum: ['4.6']
+        description: Version of the OpenShift cluster.
+
   cluster:
     type: object
     required:
@@ -2074,10 +2335,11 @@ definitions:
     properties:
       kind:
         type: string
-        enum: ['Cluster']
+        enum: ['Cluster', 'AddHostsCluster']
         description:
           Indicates the type of this object. Will be 'Cluster' if this is a complete object or
-          'ClusterLink' if it is just a link.
+          'ClusterLink' if it is just a link, 'AddHostCluster' for cluster that add hosts to
+          existing OCP cluster
       id:
         type: string
         format: uuid
@@ -2176,6 +2438,7 @@ definitions:
           - installing
           - finalizing
           - installed
+          - adding-hosts
       status_info:
         type: string
         x-go-custom-tag: gorm:"type:varchar(2048)"
@@ -2594,6 +2857,15 @@ definitions:
       type: string
       pattern: '^([0-9]{1,3}\.){3}[0-9]{1,3}\/[0-9]|[1-2][0-9]|3[0-2]?$'
 
+  connectivity_check_api_request:
+    type: object
+    required:
+      - url
+    properties:
+      url:
+        type: string
+        description: URL address of the API.
+
   credentials:
     type: object
     properties:
@@ -2694,3 +2966,11 @@ definitions:
       - 'sufficient-masters-count'
       - 'dns-domain-defined'
       - 'pull-secret-set'
+
+  logs_type:
+    type: string
+    enum:
+      - 'host'
+      - 'controller'
+      - 'all'
+      - ''

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,12 +1,30 @@
+export interface AddHostsClusterCreateParams {
+  /**
+   * Unique identifier of the object.
+   */
+  id: string; // uuid
+  /**
+   * Name of the OpenShift cluster.
+   */
+  name: string;
+  /**
+   * api vip domain.
+   */
+  apiVipDnsname: string;
+  /**
+   * Version of the OpenShift cluster.
+   */
+  openshiftVersion: '4.6';
+}
 export interface Boot {
   currentBootMode?: string;
   pxeInterface?: string;
 }
 export interface Cluster {
   /**
-   * Indicates the type of this object. Will be 'Cluster' if this is a complete object or 'ClusterLink' if it is just a link.
+   * Indicates the type of this object. Will be 'Cluster' if this is a complete object or 'ClusterLink' if it is just a link, 'AddHostCluster' for cluster that add hosts to existing OCP cluster
    */
-  kind: 'Cluster';
+  kind: 'Cluster' | 'AddHostsCluster';
   /**
    * Unique identifier of the object.
    */
@@ -85,7 +103,8 @@ export interface Cluster {
     | 'pending-for-input'
     | 'installing'
     | 'finalizing'
-    | 'installed';
+    | 'installed'
+    | 'adding-hosts';
   /**
    * Additional information pertaining to the status of the OpenShift cluster.
    */
@@ -292,6 +311,12 @@ export interface CompletionParams {
   isSuccess: boolean;
   errorInfo?: string;
 }
+export interface ConnectivityCheckApiRequest {
+  /**
+   * URL address of the API.
+   */
+  url: string;
+}
 export interface ConnectivityCheckHost {
   hostId?: string; // uuid
   nics?: ConnectivityCheckNic[];
@@ -407,9 +432,11 @@ export interface FreeNetworkAddresses {
 export type FreeNetworksAddresses = FreeNetworkAddresses[];
 export interface Host {
   /**
-   * Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link.
+   * Indicates the type of this object. Will be 'Host' if this is a complete object or 'HostLink' if it is just a link, or
+   * 'AddToExistingClusterHost' for host being added to existing OCP cluster.
+   *
    */
-  kind: 'Host';
+  kind: 'Host' | 'AddToExistingClusterHost';
   /**
    * Unique identifier of the object.
    */
@@ -436,7 +463,8 @@ export interface Host {
     | 'resetting-pending-user-action'
     | 'installed'
     | 'error'
-    | 'resetting';
+    | 'resetting'
+    | 'added-to-existing-cluster';
   statusInfo: string;
   /**
    * Json formatted string containing the validations results for each validation id grouped by category (network, hardware, etc.)
@@ -614,6 +642,7 @@ export interface ListVersions {
   versions?: Versions;
   releaseTag?: string;
 }
+export type LogsType = 'host' | 'controller' | 'all' | '';
 export interface ManagedDomain {
   domain?: string;
   provider?: 'route53';
@@ -645,7 +674,8 @@ export type StepType =
   | 'install'
   | 'free-network-addresses'
   | 'reset-installation'
-  | 'dhcp-lease-allocate';
+  | 'dhcp-lease-allocate'
+  | 'api-vip-connectivity-check';
 export interface Steps {
   nextInstructionSeconds?: number;
   instructions?: Step[];

--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -37,6 +37,8 @@ const getStatusIcon = (status: Cluster['status']): React.ReactElement => {
       return <CheckCircleIcon color={okColor.value} />;
     case 'finalizing':
       return <InProgressIcon />;
+    case 'adding-hosts':
+      return <InProgressIcon />;
   }
 };
 

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -55,6 +55,8 @@ const getStatusIcon = (status: Host['status']): React.ReactElement => {
       return <InProgressIcon />;
     case 'resetting-pending-user-action':
       return <WarningTriangleIcon color={warningColor.value} />;
+    case 'added-to-existing-cluster':
+      return <InProgressIcon />; // TODO(mlibra): hotfix only, review in a follow-up
   }
 };
 

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -50,6 +50,7 @@ export const CLUSTER_STATUS_LABELS: { [key in Cluster['status']]: string } = {
   finalizing: 'Finalizing',
   error: 'Error',
   installed: 'Installed',
+  'adding-hosts': 'Adding hosts',
 };
 
 export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
@@ -67,6 +68,7 @@ export const HOST_STATUS_LABELS: { [key in Host['status']]: string } = {
   error: 'Error',
   resetting: 'Resetting',
   'resetting-pending-user-action': 'Reboot required',
+  'added-to-existing-cluster': 'Added to existing cluster',
 };
 
 export const CLUSTER_FIELD_LABELS: { [key in string]: string } = {
@@ -103,6 +105,7 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
   resetting: 'This host is resetting the installation.',
   'resetting-pending-user-action':
     'Host already booted from disk during previous installation. To finish resetting the installation please boot the host into Discovery ISO.',
+  'added-to-existing-cluster': 'Host is added to existing cluster', // TODO(mlibra): add this new state plus cluster's adding-hosts properly (in a follow up)
 };
 
 export const HOST_VALIDATION_GROUP_LABELS: { [key in keyof ValidationsInfo]: string } = {


### PR DESCRIPTION
Updated swagger.

In addition, basic support for new host's `added-to-existing-cluster` and cluster's `adding-hosts` statuses is provided to unblock development of other feature. This needs to be revisited in a follow-up.
