### PR TITLE
Review new host-adding states

### DIFF
--- a/src/components/clusters/ClusterStatus.tsx
+++ b/src/components/clusters/ClusterStatus.tsx
@@ -25,18 +25,14 @@ const getStatusIcon = (status: Cluster['status']): React.ReactElement => {
       return <FileAltIcon />;
     case 'pending-for-input':
       return <PendingIcon />;
-    case 'ready':
-      return <CheckCircleIcon color={okColor.value} />;
-    case 'preparing-for-installation':
-      return <InProgressIcon />;
-    case 'installing':
-      return <InProgressIcon />;
     case 'error':
       return <ExclamationCircleIcon color={dangerColor.value} />;
+    case 'ready':
     case 'installed':
       return <CheckCircleIcon color={okColor.value} />;
+    case 'preparing-for-installation':
+    case 'installing':
     case 'finalizing':
-      return <InProgressIcon />;
     case 'adding-hosts':
       return <InProgressIcon />;
   }

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -56,7 +56,7 @@ const getStatusIcon = (status: Host['status']): React.ReactElement => {
     case 'resetting-pending-user-action':
       return <WarningTriangleIcon color={warningColor.value} />;
     case 'added-to-existing-cluster':
-      return <InProgressIcon />; // TODO(mlibra): hotfix only, review in a follow-up
+      return <InProgressIcon />;
   }
 };
 

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -31,30 +31,24 @@ const getStatusIcon = (status: Host['status']): React.ReactElement => {
       return <ConnectedIcon />;
     case 'pending-for-input':
       return <PendingIcon />;
-    case 'known':
-      return <CheckCircleIcon color={okColor.value} />;
     case 'disconnected':
       return <DisconnectedIcon />;
     case 'disabled':
       return <BanIcon />;
-    case 'insufficient':
-      return <WarningTriangleIcon color={warningColor.value} />;
-    case 'preparing-for-installation':
-      return <InProgressIcon />;
-    case 'installing':
-      return <InProgressIcon />;
-    case 'installing-in-progress':
-      return <InProgressIcon />;
-    case 'installing-pending-user-action':
-      return <WarningTriangleIcon color={warningColor.value} />;
     case 'error':
       return <ExclamationCircleIcon color={dangerColor.value} />;
-    case 'installed':
-      return <CheckCircleIcon color={okColor.value} />;
-    case 'resetting':
-      return <InProgressIcon />;
     case 'resetting-pending-user-action':
       return <WarningTriangleIcon color={warningColor.value} />;
+    case 'insufficient':
+    case 'installing-pending-user-action':
+      return <WarningTriangleIcon color={warningColor.value} />;
+    case 'known':
+    case 'installed':
+      return <CheckCircleIcon color={okColor.value} />;
+    case 'preparing-for-installation':
+    case 'installing':
+    case 'installing-in-progress':
+    case 'resetting':
     case 'added-to-existing-cluster':
       return <InProgressIcon />;
   }

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -105,7 +105,7 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
   resetting: 'This host is resetting the installation.',
   'resetting-pending-user-action':
     'Host already booted from disk during previous installation. To finish resetting the installation please boot the host into Discovery ISO.',
-  'added-to-existing-cluster': 'Host is added to existing cluster', // TODO(mlibra): add this new state plus cluster's adding-hosts properly (in a follow up)
+  'added-to-existing-cluster': 'This host is being added to existing cluster.',
 };
 
 export const HOST_VALIDATION_GROUP_LABELS: { [key in keyof ValidationsInfo]: string } = {

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -105,7 +105,7 @@ export const HOST_STATUS_DETAILS: { [key in Host['status']]: string } = {
   resetting: 'This host is resetting the installation.',
   'resetting-pending-user-action':
     'Host already booted from disk during previous installation. To finish resetting the installation please boot the host into Discovery ISO.',
-  'added-to-existing-cluster': 'This host is being added to existing cluster.',
+  'added-to-existing-cluster': 'This host is being added to an existing cluster.',
 };
 
 export const HOST_VALIDATION_GROUP_LABELS: { [key in keyof ValidationsInfo]: string } = {


### PR DESCRIPTION
Follow-up for added host's `added-to-existing-cluster` and cluster's `adding-hosts` statuses.

If the host is in `added-to-existing-cluster` status:
- status icon is `InProgressIcon`
- status detail text: `Host is added to existing cluster`

If the cluster is in `adding-hosts` status:
- icon: `InProgressIcon`
- Status label: `Adding hosts`

I do not see effect of these new states on our `canDo...()` UI checks atm.

Depends on:
- [x] #244