### PR TITLE
OCPBUGSM-18591 Host status alerts can be extended for user actions

### DIFF
--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -15,7 +15,7 @@ import {
   BanIcon,
   PendingIcon,
 } from '@patternfly/react-icons';
-import { Host } from '../../api/types';
+import { Cluster, Host } from '../../api/types';
 import { ValidationsInfo } from '../../types/hosts';
 import HostProgress from './HostProgress';
 import { HOST_STATUS_LABELS, HOST_STATUS_DETAILS } from '../../config/constants';
@@ -23,7 +23,7 @@ import { getHumanizedDateTime } from '../ui/utils';
 import { toSentence } from '../ui/table/utils';
 import { getHostProgressStageNumber, getHostProgressStages } from './utils';
 import { stringToJSON } from '../../api/utils';
-import HostValidationGroups from './HostValidationGroups';
+import HostValidationGroups, { ValidationInfoActionProps } from './HostValidationGroups';
 
 const getStatusIcon = (status: Host['status']): React.ReactElement => {
   switch (status) {
@@ -55,7 +55,8 @@ const getStatusIcon = (status: Host['status']): React.ReactElement => {
   }
 };
 
-const getPopoverContent = (host: Host) => {
+const getPopoverContent = (props: ValidationInfoActionProps) => {
+  const { host } = props;
   const { status, statusInfo } = host;
   const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
   const statusDetails = HOST_STATUS_DETAILS[status];
@@ -95,16 +96,18 @@ const getPopoverContent = (host: Host) => {
           {toSentence(statusInfo)}
         </Text>
       </TextContent>
-      <HostValidationGroups validationsInfo={validationsInfo} />
+      <HostValidationGroups validationsInfo={validationsInfo} {...props} />
     </>
   );
 };
 
 type HostStatusProps = {
   host: Host;
+  cluster: Cluster;
 };
 
-const HostStatus: React.FC<HostStatusProps> = ({ host }) => {
+const HostStatus: React.FC<HostStatusProps> = ({ host, cluster }) => {
+  const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
   const { status, statusUpdatedAt } = host;
   const title = HOST_STATUS_LABELS[status] || status;
   const icon = getStatusIcon(status) || null;
@@ -114,10 +117,11 @@ const HostStatus: React.FC<HostStatusProps> = ({ host }) => {
     <>
       <Popover
         headerContent={<div>{title}</div>}
-        bodyContent={getPopoverContent(host)}
+        bodyContent={getPopoverContent({ host, cluster, onValidationActionToggle })}
         footerContent={<small>Status updated at {getHumanizedDateTime(statusUpdatedAt)}</small>}
         minWidth="30rem"
         maxWidth="50rem"
+        hideOnOutsideClick={!keepOnOutsideClick}
       >
         <Button variant={ButtonVariant.link} isInline>
           {icon} {title}{' '}
@@ -128,7 +132,7 @@ const HostStatus: React.FC<HostStatusProps> = ({ host }) => {
           )}
         </Button>
       </Popover>
-      {status === 'installing-pending-user-action' && (
+      {['installing-pending-user-action', 'disconnected'].includes(status) && (
         <div className="hosts-table-sublabel">Action required</div>
       )}
     </>

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -122,6 +122,7 @@ const HostStatus: React.FC<HostStatusProps> = ({ host, cluster }) => {
         minWidth="30rem"
         maxWidth="50rem"
         hideOnOutsideClick={!keepOnOutsideClick}
+        zIndex={keepOnOutsideClick ? 300 : undefined}
       >
         <Button variant={ButtonVariant.link} isInline>
           {icon} {title}{' '}

--- a/src/components/hosts/HostValidationGroups.css
+++ b/src/components/hosts/HostValidationGroups.css
@@ -2,3 +2,7 @@
   margin-top: var(--pf-global--spacer--md) !important;
   margin-bottom: var(--pf-global--spacer--sm) !important;
 }
+
+.host-validation-groups__validation_action {
+  float: right;
+}

--- a/src/components/hosts/HostValidationGroups.css
+++ b/src/components/hosts/HostValidationGroups.css
@@ -2,7 +2,3 @@
   margin-top: var(--pf-global--spacer--md) !important;
   margin-bottom: var(--pf-global--spacer--sm) !important;
 }
-
-.host-validation-groups__validation_action {
-  float: right;
-}

--- a/src/components/hosts/HostValidationGroups.tsx
+++ b/src/components/hosts/HostValidationGroups.tsx
@@ -28,44 +28,36 @@ type ValidationGroupAlertProps = ValidationInfoActionProps & {
   title: string;
 };
 
-const ValidationInfoAction: React.FC<ValidationInfoActionProps & { validation: Validation }> = ({
-  validation,
-  onValidationActionToggle,
-  ...props
-}) => {
-  if (
-    validation.status === 'failure' &&
-    ['hostname-unique', 'hostname-valid'].includes(validation.id)
-  ) {
-    return (
-      <Hostname
-        title="Change hostname"
-        className="host-validation-groups__validation_action"
-        onToggle={onValidationActionToggle}
-        {...props}
-      />
-    );
-  }
-
-  return null;
-};
-
 const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
   variant,
   validations,
   title,
+  onValidationActionToggle,
   ...props
 }) => {
   if (!validations.length) {
     return null;
   }
+
+  const actionLinks = [];
+  if (
+    validations.find(
+      (validation) =>
+        validation.status === 'failure' &&
+        ['hostname-unique', 'hostname-valid'].includes(validation.id),
+    )
+  ) {
+    actionLinks.push(
+      <Hostname title="Change hostname" onToggle={onValidationActionToggle} {...props} />,
+    );
+  }
+
   return (
-    <Alert title={title} variant={variant} isInline>
+    <Alert title={title} variant={variant} actionLinks={actionLinks} isInline>
       <ul>
         {validations.map((v) => (
           <li key={v.id}>
             <strong>{HOST_VALIDATION_LABELS[v.id]}:</strong>&nbsp;{v.message}&nbsp;
-            <ValidationInfoAction validation={v} {...props} />
           </li>
         ))}
       </ul>

--- a/src/components/hosts/Hostname.tsx
+++ b/src/components/hosts/Hostname.tsx
@@ -5,22 +5,43 @@ import { Host, Inventory, Cluster } from '../../api/types';
 
 type HostnameProps = {
   host: Host;
-  inventory: Inventory;
   cluster: Cluster;
+  className?: string;
+  onToggle?: (isOpen: boolean) => void;
+  // Provide either inventory or title
+  inventory?: Inventory;
+  title?: string;
 };
 
 export const computeHostname = (host: Host, inventory: Inventory) =>
   host.requestedHostname || inventory.hostname;
 
-const Hostname: React.FC<HostnameProps> = ({ host, inventory, cluster }) => {
-  const [isOpen, setOpen] = React.useState(false);
+const Hostname: React.FC<HostnameProps> = ({
+  host,
+  inventory = {},
+  cluster,
+  title,
+  className,
+  onToggle,
+}) => {
+  const [isOpen, _setOpen] = React.useState(false);
 
-  const hostname = computeHostname(host, inventory);
-  const isHostnameChangeRequested = host.requestedHostname !== inventory.hostname;
+  const setOpen = (isOpen: boolean) => {
+    onToggle && onToggle(isOpen);
+    _setOpen(isOpen);
+  };
+
+  const hostname = title || computeHostname(host, inventory);
+  const isHostnameChangeRequested = !title && host.requestedHostname !== inventory.hostname;
 
   return (
     <>
-      <Button variant={ButtonVariant.link} isInline onClick={() => setOpen(true)}>
+      <Button
+        variant={ButtonVariant.link}
+        isInline
+        onClick={() => setOpen(true)}
+        className={className}
+      >
         {hostname}
         {isHostnameChangeRequested && ' *'}
       </Button>

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -99,7 +99,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
           sortableValue: getHostRole(host),
         },
         {
-          title: <HostStatus host={host} />,
+          title: <HostStatus host={host} cluster={cluster} />,
           sortableValue: status,
         },
         getDateTimeCell(createdAt),


### PR DESCRIPTION
The first user action is the hostname change in case of 'hostname-unique' or 'hostname-valid' host state.