### PR TITLE
Move the cluster list toolbar actions above the table to align with OCM

### DIFF
--- a/src/components/clusters/Clusters.tsx
+++ b/src/components/clusters/Clusters.tsx
@@ -7,14 +7,10 @@ import {
   PageSectionVariants,
   TextContent,
   Text,
-  TextVariants,
-  Spinner,
 } from '@patternfly/react-core';
 import PageSection from '../ui/PageSection';
 import { selectClusterTableRows, selectClustersUIState } from '../../selectors/clusters';
 import { routeBasePath } from '../../config/constants';
-import { ToolbarText, ToolbarButton } from '../ui/Toolbar';
-import ClusterToolbar from './ClusterToolbar';
 import { LoadingState, ErrorState, EmptyState } from '../ui/uiState';
 import { AddCircleOIcon } from '@patternfly/react-icons';
 import { ResourceUIState } from '../../types';
@@ -106,23 +102,6 @@ const Clusters: React.FC<ClustersProps> = ({ history }) => {
             <ClustersTable rows={clusterRows} deleteCluster={deleteClusterAsync} />
           </PageSection>
           <AlertsSection />
-          <ClusterToolbar>
-            <ToolbarButton
-              variant={ButtonVariant.primary}
-              onClick={() => history.push(`${routeBasePath}/clusters/~new`)}
-              id="button-create-new-cluster"
-              data-ouia-id="button-create-new-cluster"
-            >
-              Create New Cluster
-            </ToolbarButton>
-            <ToolbarText component={TextVariants.small}>
-              {clustersUIState === RELOADING && (
-                <>
-                  <Spinner size="sm" /> Fetching clusters...
-                </>
-              )}
-            </ToolbarText>
-          </ClusterToolbar>
         </>
       );
   }

--- a/src/components/clusters/ClustersListToolbar.tsx
+++ b/src/components/clusters/ClustersListToolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import {
   Toolbar,
@@ -16,13 +16,16 @@ import {
   TextInputProps,
   ButtonVariant,
   Spinner,
+  ToolbarGroup,
+  Tooltip,
 } from '@patternfly/react-core';
-import { FilterIcon } from '@patternfly/react-icons';
+import { FilterIcon, SyncIcon } from '@patternfly/react-icons';
 import { Cluster } from '../../api/types';
 import { CLUSTER_STATUS_LABELS, routeBasePath } from '../../config';
 import ToolbarButton from '../ui/Toolbar/ToolbarButton';
 import { ResourceUIState } from '../../types';
 import { selectClustersUIState } from '../../selectors/clusters';
+import { fetchClustersAsync } from '../../features/clusters/clustersSlice';
 
 export type ClusterFiltersType = {
   [key: string]: string[]; // value from CLUSTER_STATUS_LABELS
@@ -44,6 +47,8 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
   const [isStatusExpanded, setStatusExpanded] = React.useState(false);
   const history = useHistory();
   const clustersUIState = useSelector(selectClustersUIState);
+  const dispatch = useDispatch();
+  const fetchClusters = React.useCallback(() => dispatch(fetchClustersAsync()), [dispatch]);
 
   const onClearAllFilters: ToolbarProps['clearAllFilters'] = () => {
     setFilters({
@@ -110,8 +115,8 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
               aria-label="string to be searched in cluster names or ids"
               onChange={onSearchNameChanged}
               value={searchString}
-              placeholder="Search by Name, ID or Base domain"
-              title="Search by Name, ID or Base domain"
+              placeholder="Filter by Name, ID or Base domain"
+              title="Filter by Name, ID or Base domain"
             />
           </InputGroup>
         </ToolbarItem>
@@ -141,9 +146,20 @@ const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
           id="button-create-new-cluster"
           data-ouia-id="button-create-new-cluster"
         >
-          Create New Cluster
+          Create Cluster
         </ToolbarButton>
         {clustersUIState === ResourceUIState.RELOADING && <Spinner size="lg" />}
+        <ToolbarGroup alignment={{ lg: 'alignRight' }}>
+          <ToolbarButton
+            variant={ButtonVariant.plain}
+            onClick={() => fetchClusters()}
+            isDisabled={clustersUIState === ResourceUIState.RELOADING}
+          >
+            <Tooltip content="Refresh">
+              <SyncIcon />
+            </Tooltip>
+          </ToolbarButton>
+        </ToolbarGroup>
       </ToolbarContent>
     </Toolbar>
   );

--- a/src/components/clusters/ClustersListToolbar.tsx
+++ b/src/components/clusters/ClustersListToolbar.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import {
   Toolbar,
   ToolbarItem,
@@ -12,29 +14,36 @@ import {
   ToolbarFilterProps,
   SelectProps,
   TextInputProps,
+  ButtonVariant,
+  Spinner,
 } from '@patternfly/react-core';
 import { FilterIcon } from '@patternfly/react-icons';
 import { Cluster } from '../../api/types';
-import { CLUSTER_STATUS_LABELS } from '../../config';
+import { CLUSTER_STATUS_LABELS, routeBasePath } from '../../config';
+import ToolbarButton from '../ui/Toolbar/ToolbarButton';
+import { ResourceUIState } from '../../types';
+import { selectClustersUIState } from '../../selectors/clusters';
 
 export type ClusterFiltersType = {
   [key: string]: string[]; // value from CLUSTER_STATUS_LABELS
 };
 
-type ClustersFilterToolbarProps = {
+type ClustersListToolbarProps = {
   searchString: string;
   setSearchString: (value: string) => void;
   filters: ClusterFiltersType;
   setFilters: (filters: ClusterFiltersType) => void;
 };
 
-const ClustersFilterToolbar: React.FC<ClustersFilterToolbarProps> = ({
+const ClustersListToolbar: React.FC<ClustersListToolbarProps> = ({
   searchString,
   setSearchString,
   filters,
   setFilters,
 }) => {
   const [isStatusExpanded, setStatusExpanded] = React.useState(false);
+  const history = useHistory();
+  const clustersUIState = useSelector(selectClustersUIState);
 
   const onClearAllFilters: ToolbarProps['clearAllFilters'] = () => {
     setFilters({
@@ -86,7 +95,7 @@ const ClustersFilterToolbar: React.FC<ClustersFilterToolbarProps> = ({
 
   return (
     <Toolbar
-      id="clusters-filter-toolbar"
+      id="clusters-list-toolbar"
       className="pf-m-toggle-group-container"
       collapseListedFiltersBreakpoint="xl"
       clearAllFilters={onClearAllFilters}
@@ -126,9 +135,18 @@ const ClustersFilterToolbar: React.FC<ClustersFilterToolbarProps> = ({
             ))}
           </Select>
         </ToolbarFilter>
+        <ToolbarButton
+          variant={ButtonVariant.primary}
+          onClick={() => history.push(`${routeBasePath}/clusters/~new`)}
+          id="button-create-new-cluster"
+          data-ouia-id="button-create-new-cluster"
+        >
+          Create New Cluster
+        </ToolbarButton>
+        {clustersUIState === ResourceUIState.RELOADING && <Spinner size="lg" />}
       </ToolbarContent>
     </Toolbar>
   );
 };
 
-export default ClustersFilterToolbar;
+export default ClustersListToolbar;

--- a/src/components/clusters/ClustersTable.tsx
+++ b/src/components/clusters/ClustersTable.tsx
@@ -19,7 +19,7 @@ import sortable from '../ui/table/sortable';
 import DeleteClusterModal from './DeleteClusterModal';
 import { getClusterTableStatusCell } from '../../selectors/clusters';
 import { CLUSTER_STATUS_LABELS } from '../../config/constants';
-import ClustersFilterToolbar, { ClusterFiltersType } from './ClustersFilterToolbar';
+import ClustersListToolbar, { ClusterFiltersType } from './ClustersListToolbar';
 
 const rowKey = ({ rowData }: ExtraParamsType) => rowData?.props.id;
 
@@ -150,7 +150,7 @@ const ClustersTable: React.FC<ClustersTableProps> = ({ rows, deleteCluster }) =>
 
   return (
     <>
-      <ClustersFilterToolbar
+      <ClustersListToolbar
         searchString={searchString}
         setSearchString={setSearchString}
         filters={filters}

--- a/src/components/ui/ClusterEventsToolbar.tsx
+++ b/src/components/ui/ClusterEventsToolbar.tsx
@@ -33,7 +33,7 @@ export type ClusterEventsFiltersType = {
   orphanedHosts: boolean;
 };
 
-type ClustersFilterToolbarProps = {
+type ClustersListToolbarProps = {
   filters: ClusterEventsFiltersType;
   setFilters: (filters: ClusterEventsFiltersType) => void;
   cluster: Cluster;
@@ -74,7 +74,7 @@ export const getInitialClusterEventsFilters = (cluster: Cluster): ClusterEventsF
 const getEventsCount = (severity: Event['severity'], events: Event[]) =>
   events.filter((event) => event.severity === severity).length;
 
-const ClusterEventsToolbar: React.FC<ClustersFilterToolbarProps> = ({
+const ClusterEventsToolbar: React.FC<ClustersListToolbarProps> = ({
   filters,
   setFilters,
   cluster,


### PR DESCRIPTION
Depends on https://github.com/mareklibra/facet-lib/pull/255

Move the cluster list toolbar actions above the table
To align to OCM cluster list the botton toolbar is removed in clusters list and actions are put into clusters table toolbar.

Add 'refresh' button to cluster list toolbar

![image](https://user-images.githubusercontent.com/1121740/95826363-778a2480-0d32-11eb-9569-6d2a342cfdfa.png)
