### PR TITLE
MGMT-2339 Breadcrumb navigates to OCM list

### DIFF
--- a/src/components/clusters/ClusterBreadcrumbs.tsx
+++ b/src/components/clusters/ClusterBreadcrumbs.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import PageSection from '../ui/PageSection';
 import { isSingleClusterMode, routeBasePath } from '../../config';
 import DeveloperPreview from '../ui/DeveloperPreview';
+import { ocmClient } from '../../api';
 
 type Props = {
   clusterName?: string;
@@ -13,12 +14,21 @@ type Props = {
 const ClusterBreadcrumbs: React.FC<Props> = ({ clusterName, isHidden = isSingleClusterMode() }) =>
   isHidden ? null : (
     <PageSection variant={PageSectionVariants.light}>
-      <Breadcrumb>
-        <BreadcrumbItem>
-          <Link to={`${routeBasePath}/clusters`}>Clusters</Link>
-        </BreadcrumbItem>
-        <BreadcrumbItem isActive>{clusterName}</BreadcrumbItem>
-      </Breadcrumb>
+      {(clusterName || ocmClient) && (
+        <Breadcrumb>
+          <BreadcrumbItem>
+            <Link to={'/'}>Clusters</Link>
+          </BreadcrumbItem>
+          {clusterName ? (
+            <BreadcrumbItem>
+              <Link to={`${routeBasePath}/clusters`}>Assisted Bare Metal Clusters</Link>
+            </BreadcrumbItem>
+          ) : (
+            <BreadcrumbItem isActive>Assisted Bare Metal Clusters</BreadcrumbItem>
+          )}
+          {clusterName && <BreadcrumbItem isActive>{clusterName}</BreadcrumbItem>}
+        </Breadcrumb>
+      )}
       <DeveloperPreview />
     </PageSection>
   );

--- a/src/components/clusters/Clusters.tsx
+++ b/src/components/clusters/Clusters.tsx
@@ -24,7 +24,7 @@ import { deleteCluster as ApiDeleteCluster } from '../../api/clusters';
 import AlertsSection from '../ui/AlertsSection';
 import { handleApiError, getErrorMessage } from '../../api/utils';
 import { AlertsContext, AlertsContextProvider } from '../AlertsContextProvider';
-import DeveloperPreview from '../ui/DeveloperPreview';
+import ClusterBreadcrumbs from './ClusterBreadcrumbs';
 
 type ClustersProps = RouteComponentProps;
 
@@ -96,8 +96,8 @@ const Clusters: React.FC<ClustersProps> = ({ history }) => {
     default:
       return (
         <>
+          <ClusterBreadcrumbs />
           <PageSection variant={PageSectionVariants.light}>
-            <DeveloperPreview />
             <TextContent>
               <Text component="h1">Assisted Bare Metal Clusters</Text>
             </TextContent>


### PR DESCRIPTION
In OCM, the AI list newly contains breadcrumbs `Clusters > Assisted Bare Metal Clusters`.
In stand-alone application, the AI list stays without breadcrumbs (make no sense there and look weird).

All other occurrences of breadcrumbs have these two items instead of former single `Clusters`.

The breadcrumb items newly:
- `Clusters`        --> OCM cluster list
- `Clusters > Assisted Bare Metal Clusters `         --> "our" AI list
- `Clusters > Assisted Bare Metal Clusters > New cluster`
- `Clusters > Assisted Bare Metal Clusters > my-cluster-name`
