### PR TITLE
Decide the ClusterPage content by cluster.status

### DIFF
--- a/src/components/clusters/ClusterPage.tsx
+++ b/src/components/clusters/ClusterPage.tsx
@@ -77,7 +77,7 @@ const ClusterPage: React.FC<RouteComponentProps<MatchParams>> = ({ match }) => {
   }
 
   const getContent = (cluster: Cluster) => {
-    if (cluster.kind === 'AddHostsCluster') {
+    if (cluster.status === 'adding-hosts') {
       return <AddBareMetalHosts cluster={cluster} />;
     } else if (
       [


### PR DESCRIPTION
Day 2 cluster has constant status 'adding-hosts'. This change makes the
decision making on what to display on ClusterPage by cluster.status.