### PR TITLE
Use query to look-up Day 2 cluster

### DIFF
--- a/src/api/clusters.ts
+++ b/src/api/clusters.ts
@@ -16,6 +16,8 @@ import { client, BASE_PATH } from './axiosClient';
 export const getClusters = (): AxiosPromise<Cluster[]> => client.get('/clusters');
 
 export const getCluster = (id: string): AxiosPromise<Cluster> => client.get(`/clusters/${id}`);
+export const getClustersByOpenshiftId = (openshiftId: string): AxiosPromise<Cluster[]> =>
+  client.get(`/clusters?openshift_cluster_id=${openshiftId}`);
 
 export const postCluster = (params: ClusterCreateParams): AxiosPromise<Cluster> =>
   client.post('/clusters', params);

--- a/src/components/AddBareMetalHosts/utils.ts
+++ b/src/components/AddBareMetalHosts/utils.ts
@@ -1,8 +1,8 @@
 import { OcmClusterType } from './types';
 
-export const getOcmClusterId = (ocmCluster: OcmClusterType) => ocmCluster.external_id;
+export const getOpenshiftClusterId = (ocmCluster: OcmClusterType) => ocmCluster.external_id;
 
 export const canAddBareMetalHost = ({ cluster }: { cluster: OcmClusterType }) =>
   cluster.state === 'ready' &&
-  !!getOcmClusterId(cluster) &&
+  !!getOpenshiftClusterId(cluster) &&
   cluster.cloud_provider?.id === 'baremetal';


### PR DESCRIPTION
Since API has been extended for openshift_cluster_id, we do not need to assume
that the Day 2 cluster is stored with the AI ID equal to the OpenShift ID
but rather look-up it based on the ID value.

---
The look-up requires https://github.com/openshift/assisted-service/commit/6eac158645777354c302f9658be45b2d0cc78ec2, which is expected to be deployed to prod on Nov 30th. Anyway, the code is working even without this patch.