### PR TITLE
MGMT-3077 Add support for NTP configuration

### DIFF
--- a/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -39,7 +39,7 @@ const AdvancedNetworkFields: React.FC = () => {
         isRequired
       />
       <InputField
-        name="ntpSource"
+        name="additionalNtpSource"
         label="Additional NTP Source"
         helperText="IP or domain name of the NTP pool or server. Additional NTP source is added to all hosts to ensure all hosts clocks are synchronized with a valid NTP server."
       />

--- a/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -38,6 +38,12 @@ const AdvancedNetworkFields: React.FC = () => {
         helperText="The IP address pool to use for service IP addresses. You can enter only one IP address pool. If you need to access the services from an external network, configure load balancers and routers to manage the traffic."
         isRequired
       />
+      <InputField
+        name="ntpSource"
+        label="NTP Source"
+        helperText="IP or domain name of the NTP pool or server. NTP source is going to be added to all hosts to ensure all hosts clocks are synchronized through a valid NTP server."
+        placeholder="clock.redhat.com"
+      />
     </>
   );
 };

--- a/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
+++ b/src/components/clusterConfiguration/AdvancedNetworkFields.tsx
@@ -40,9 +40,8 @@ const AdvancedNetworkFields: React.FC = () => {
       />
       <InputField
         name="ntpSource"
-        label="NTP Source"
-        helperText="IP or domain name of the NTP pool or server. NTP source is going to be added to all hosts to ensure all hosts clocks are synchronized through a valid NTP server."
-        placeholder="clock.redhat.com"
+        label="Additional NTP Source"
+        helperText="IP or domain name of the NTP pool or server. Additional NTP source is added to all hosts to ensure all hosts clocks are synchronized with a valid NTP server."
       />
     </>
   );

--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -40,6 +40,7 @@ import {
   dnsNameValidationSchema,
   hostPrefixValidationSchema,
   vipValidationSchema,
+  ntpSourceValidationSchema,
 } from '../ui/formik/validationSchemas';
 import ClusterBreadcrumbs from '../clusters/ClusterBreadcrumbs';
 import { HostSubnets, ClusterConfigurationValues } from '../../types/clusters';
@@ -62,6 +63,7 @@ const validationSchema = (initialValues: ClusterConfigurationValues, hostSubnets
       apiVip: vipValidationSchema(hostSubnets, values, initialValues.apiVip),
       ingressVip: vipValidationSchema(hostSubnets, values, initialValues.ingressVip),
       sshPublicKey: sshPublicKeyValidationSchema,
+      ntpSource: ntpSourceValidationSchema,
     }),
   );
 

--- a/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
+++ b/src/components/clusterConfiguration/ClusterConfigurationForm.tsx
@@ -63,7 +63,7 @@ const validationSchema = (initialValues: ClusterConfigurationValues, hostSubnets
       apiVip: vipValidationSchema(hostSubnets, values, initialValues.apiVip),
       ingressVip: vipValidationSchema(hostSubnets, values, initialValues.ingressVip),
       sshPublicKey: sshPublicKeyValidationSchema,
-      ntpSource: ntpSourceValidationSchema,
+      additionalNtpSource: ntpSourceValidationSchema,
     }),
   );
 

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -48,7 +48,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkHostPrefix,
       );
       setFieldValue('serviceNetworkCidr', CLUSTER_DEFAULT_NETWORK_SETTINGS.serviceNetworkCidr);
-      setFieldValue('ntpSource', CLUSTER_DEFAULT_NETWORK_SETTINGS.ntpSource);
+      setFieldValue('additionalNtpSource', CLUSTER_DEFAULT_NETWORK_SETTINGS.additionalNtpSource);
     }
   };
 

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -89,7 +89,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
       <Checkbox
         id="useAdvancedNetworking"
         label="Use Advanced Networking"
-        description="Configure a custom networking type and CIDR ranges"
+        description="Configure advanced networking properties (CIDR ranges, NTP)."
         isChecked={isAdvanced}
         onChange={toggleAdvConfiguration}
       />

--- a/src/components/clusterConfiguration/NetworkConfiguration.tsx
+++ b/src/components/clusterConfiguration/NetworkConfiguration.tsx
@@ -48,6 +48,7 @@ const NetworkConfiguration: React.FC<NetworkConfigurationProps> = ({
         CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkHostPrefix,
       );
       setFieldValue('serviceNetworkCidr', CLUSTER_DEFAULT_NETWORK_SETTINGS.serviceNetworkCidr);
+      setFieldValue('ntpSource', CLUSTER_DEFAULT_NETWORK_SETTINGS.ntpSource);
     }
   };
 

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -37,10 +37,11 @@ export const getSubnetFromMachineNetworkCidr = (machineNetworkCidr?: string) => 
   return `${subnet.toString()} (${subnet.first}-${subnet.last})`;
 };
 
-export const isAdvConf = (cluster: Cluster) =>
+export const isAdvConf = (cluster: Cluster): boolean =>
   cluster.clusterNetworkCidr !== CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkCidr ||
   cluster.clusterNetworkHostPrefix !== CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkHostPrefix ||
-  cluster.serviceNetworkCidr !== CLUSTER_DEFAULT_NETWORK_SETTINGS.serviceNetworkCidr;
+  cluster.serviceNetworkCidr !== CLUSTER_DEFAULT_NETWORK_SETTINGS.serviceNetworkCidr ||
+  cluster.ntpSource !== CLUSTER_DEFAULT_NETWORK_SETTINGS.ntpSource;
 
 export const getInitialValues = (
   cluster: Cluster,
@@ -63,4 +64,5 @@ export const getInitialValues = (
   shareDiscoverySshKey:
     !!cluster.imageInfo.sshPublicKey && cluster.sshPublicKey === cluster.imageInfo.sshPublicKey,
   vipDhcpAllocation: cluster.vipDhcpAllocation,
+  ntpSource: cluster.ntpSource || '',
 });

--- a/src/components/clusterConfiguration/utils.ts
+++ b/src/components/clusterConfiguration/utils.ts
@@ -41,7 +41,7 @@ export const isAdvConf = (cluster: Cluster): boolean =>
   cluster.clusterNetworkCidr !== CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkCidr ||
   cluster.clusterNetworkHostPrefix !== CLUSTER_DEFAULT_NETWORK_SETTINGS.clusterNetworkHostPrefix ||
   cluster.serviceNetworkCidr !== CLUSTER_DEFAULT_NETWORK_SETTINGS.serviceNetworkCidr ||
-  cluster.ntpSource !== CLUSTER_DEFAULT_NETWORK_SETTINGS.ntpSource;
+  cluster.additionalNtpSource !== CLUSTER_DEFAULT_NETWORK_SETTINGS.additionalNtpSource;
 
 export const getInitialValues = (
   cluster: Cluster,
@@ -64,5 +64,5 @@ export const getInitialValues = (
   shareDiscoverySshKey:
     !!cluster.imageInfo.sshPublicKey && cluster.sshPublicKey === cluster.imageInfo.sshPublicKey,
   vipDhcpAllocation: cluster.vipDhcpAllocation,
-  ntpSource: cluster.ntpSource || '',
+  additionalNtpSource: cluster.additionalNtpSource || '',
 });

--- a/src/components/hosts/HostRowDetail.tsx
+++ b/src/components/hosts/HostRowDetail.tsx
@@ -7,10 +7,13 @@ import { Host, Inventory, Disk, Interface } from '../../api/types';
 import { getHostRowHardwareInfo } from './hardwareInfo';
 import { DASH } from '../constants';
 import { DetailList, DetailListProps, DetailItem } from '../ui/DetailList';
+import { ValidationsInfo } from '../../types/hosts';
+import NtpValidationStatus from './NtpValidationStatus';
 
 type HostDetailProps = {
   inventory: Inventory;
   host: Host;
+  validationsInfo: ValidationsInfo;
 };
 
 type SectionTitleProps = {
@@ -123,7 +126,7 @@ const NicsTable: React.FC<NicsTableProps> = ({ interfaces }) => {
   );
 };
 
-export const HostDetail: React.FC<HostDetailProps> = ({ inventory, host }) => {
+export const HostDetail: React.FC<HostDetailProps> = ({ inventory, host, validationsInfo }) => {
   const { id } = host;
   const rowInfo = getHostRowHardwareInfo(inventory);
   const disks = inventory.disks || [];
@@ -164,6 +167,10 @@ export const HostDetail: React.FC<HostDetailProps> = ({ inventory, host }) => {
         {inventory.boot?.pxeInterface && (
           <DetailItem title="PXE interface" value={inventory.boot?.pxeInterface} />
         )}
+        <DetailItem
+          title="NTP status"
+          value={<NtpValidationStatus validationsInfo={validationsInfo} />}
+        />
       </SectionColumn>
 
       <SectionTitle title={`${disks.length} Disk${disks.length === 1 ? '' : 's'}`} />

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -24,7 +24,6 @@ import { HOST_STATUS_LABELS, HOST_STATUS_DETAILS } from '../../config/constants'
 import { getHumanizedDateTime } from '../ui/utils';
 import { toSentence } from '../ui/table/utils';
 import { getHostProgressStageNumber, getHostProgressStages } from './utils';
-import { stringToJSON } from '../../api/utils';
 import HostValidationGroups, { ValidationInfoActionProps } from './HostValidationGroups';
 import OcpConsoleNodesSectionLink from './OcpConsoleNodesSectionLink';
 
@@ -59,10 +58,13 @@ const getStatusIcon = (status: Host['status']): React.ReactElement => {
   }
 };
 
-const HostStatusPopoverContent: React.FC<ValidationInfoActionProps> = (props) => {
+type HostStatusPopoverContentProps = ValidationInfoActionProps & {
+  validationsInfo: ValidationsInfo;
+};
+
+const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = (props) => {
   const { host } = props;
   const { status, statusInfo } = host;
-  const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
   const statusDetails = HOST_STATUS_DETAILS[status];
 
   if (status === 'added-to-existing-cluster') {
@@ -115,13 +117,14 @@ const HostStatusPopoverContent: React.FC<ValidationInfoActionProps> = (props) =>
           {toSentence(statusInfo)}
         </Text>
       </TextContent>
-      <HostValidationGroups validationsInfo={validationsInfo} {...props} />
+      <HostValidationGroups {...props} />
     </>
   );
 };
 
 type HostStatusProps = {
   host: Host;
+  validationsInfo: ValidationsInfo;
   cluster: Cluster;
 };
 
@@ -154,7 +157,7 @@ const HostStatusPopoverFooter: React.FC<{ host: Host }> = ({ host }) => {
   return <small>{footerText}</small>;
 };
 
-const HostStatus: React.FC<HostStatusProps> = ({ host, cluster }) => {
+const HostStatus: React.FC<HostStatusProps> = ({ host, cluster, validationsInfo }) => {
   const [keepOnOutsideClick, onValidationActionToggle] = React.useState(false);
   const { status } = host;
   const title = HOST_STATUS_LABELS[status] || status;
@@ -168,6 +171,7 @@ const HostStatus: React.FC<HostStatusProps> = ({ host, cluster }) => {
         bodyContent={
           <HostStatusPopoverContent
             host={host}
+            validationsInfo={validationsInfo}
             cluster={cluster}
             onValidationActionToggle={onValidationActionToggle}
           />

--- a/src/components/hosts/HostStatus.tsx
+++ b/src/components/hosts/HostStatus.tsx
@@ -106,17 +106,11 @@ const HostStatusPopoverContent: React.FC<HostStatusPopoverContentProps> = (props
 
   return (
     <>
-      <TextContent>
-        <Text>
-          {statusDetails && (
-            <>
-              {statusDetails}
-              <br />
-            </>
-          )}
-          {toSentence(statusInfo)}
-        </Text>
-      </TextContent>
+      {statusDetails && (
+        <TextContent>
+          <Text>{statusDetails}</Text>
+        </TextContent>
+      )}
       <HostValidationGroups {...props} />
     </>
   );

--- a/src/components/hosts/HostValidationGroups.tsx
+++ b/src/components/hosts/HostValidationGroups.tsx
@@ -6,11 +6,16 @@ import {
 } from '@patternfly/react-tokens';
 import { PendingIcon, CheckCircleIcon, WarningTriangleIcon } from '@patternfly/react-icons';
 import { ValidationsInfo, Validation } from '../../types/hosts';
-import { HOST_VALIDATION_GROUP_LABELS, HOST_VALIDATION_LABELS } from '../../config/constants';
+import {
+  HOST_VALIDATION_GROUP_LABELS,
+  HOST_VALIDATION_HINTS,
+  HOST_VALIDATION_LABELS,
+} from '../../config/constants';
 import { Cluster, Host } from '../../api';
 import Hostname from './Hostname';
 
 import './HostValidationGroups.css';
+import { toSentence } from '../ui/table/utils';
 
 export type ValidationInfoActionProps = {
   host: Host;
@@ -62,7 +67,8 @@ const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
       <ul>
         {validations.map((v) => (
           <li key={v.id}>
-            <strong>{HOST_VALIDATION_LABELS[v.id] || v.id}:</strong>&nbsp;{v.message}&nbsp;
+            <strong>{HOST_VALIDATION_LABELS[v.id] || v.id}:</strong>&nbsp;{toSentence(v.message)}{' '}
+            {v.status === 'failure' && HOST_VALIDATION_HINTS[v.id]}
           </li>
         ))}
       </ul>

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -60,6 +60,7 @@ import Hostname, { computeHostname } from './Hostname';
 import HostsCount from './HostsCount';
 
 import './HostsTable.css';
+import { ValidationsInfo } from '../../types/hosts';
 
 type HostsTableProps = {
   cluster: Cluster;
@@ -94,6 +95,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
   const inventory = stringToJSON<Inventory>(inventoryString) || {};
   const { cores, memory, disk } = getHostRowHardwareInfo(inventory);
   const computedHostname = computeHostname(host, inventory);
+  const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
   return [
     {
       // visible row
@@ -112,7 +114,7 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
           sortableValue: getHostRole(host),
         },
         {
-          title: <HostStatus host={host} cluster={cluster} />,
+          title: <HostStatus host={host} cluster={cluster} validationsInfo={validationsInfo} />,
           sortableValue: status,
         },
         getDateTimeCell(createdAt),
@@ -129,7 +131,18 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
       // expandable detail
       // parent will be set after sorting
       fullWidth: true,
-      cells: [{ title: <HostDetail key={id} inventory={inventory} host={host} /> }],
+      cells: [
+        {
+          title: (
+            <HostDetail
+              key={id}
+              inventory={inventory}
+              host={host}
+              validationsInfo={validationsInfo}
+            />
+          ),
+        },
+      ],
       key: `${host.id}-detail`,
       inventory,
     },

--- a/src/components/hosts/NtpValidationStatus.tsx
+++ b/src/components/hosts/NtpValidationStatus.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { CheckCircleIcon, ExclamationCircleIcon, PendingIcon } from '@patternfly/react-icons';
+import {
+  global_danger_color_100 as dangerColor,
+  global_success_color_100 as successColor,
+} from '@patternfly/react-tokens';
+import { ValidationsInfo } from '../../types/hosts';
+
+const NtpValidationStatus: React.FC<{ validationsInfo: ValidationsInfo }> = ({
+  validationsInfo,
+}) => {
+  const ntpSyncedValidation = validationsInfo.network?.find((v) => v.id === 'ntp-synced');
+  switch (ntpSyncedValidation?.status) {
+    case 'success':
+      return (
+        <>
+          <CheckCircleIcon color={successColor.value} /> Synced
+        </>
+      );
+    case 'failure':
+      return (
+        <>
+          <ExclamationCircleIcon color={dangerColor.value} /> Unreachable (Configure NTP source in
+          Advanced networking section)
+        </>
+      );
+    case 'pending':
+      return (
+        <>
+          <PendingIcon /> Pending
+        </>
+      );
+    default:
+      return (
+        <>
+          <ExclamationCircleIcon color={dangerColor.value} /> Failed to validate NTP status
+        </>
+      );
+  }
+};
+export default NtpValidationStatus;

--- a/src/components/ui/formik/validationSchemas.ts
+++ b/src/components/ui/formik/validationSchemas.ts
@@ -228,3 +228,20 @@ export const noProxyValidationSchema = Yup.string().test(
       });
   },
 );
+
+export const ntpSourceValidationSchema = Yup.string().test(
+  'ntp-source-validation',
+  'Provide a valid DNS or IP address.',
+  (value: string) => {
+    if (!value) {
+      return true;
+    }
+    if (value.match(DNS_NAME_REGEX)) {
+      return true;
+    }
+    if (value.match(IP_ADDRESS_REGEX)) {
+      return true;
+    }
+    return false;
+  },
+);

--- a/src/components/ui/table/utils.ts
+++ b/src/components/ui/table/utils.ts
@@ -47,7 +47,7 @@ export const rowSorter = (sortBy: ISortBy, getCell: getCellType) => (a: IRow, b:
 
 /** Converts string into a sentence by capitalizing first letter and appending with . */
 export const toSentence = (s: string) =>
-  `${_.capitalize(s)}${_.endsWith(s, '.') || s === '' ? '' : '.'}`;
+  `${_.upperFirst(s)}${_.endsWith(s, '.') || s === '' ? '' : '.'}`;
 
 export const getDateTimeCell = (time?: string): HumanizedSortable => {
   const date = getHumanizedDateTime(time);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -189,7 +189,7 @@ export const CLUSTER_DEFAULT_NETWORK_SETTINGS = {
   clusterNetworkCidr: '10.128.0.0/14',
   clusterNetworkHostPrefix: 23,
   serviceNetworkCidr: '172.30.0.0/16',
-  ntpSource: '0.rhel.pool.ntp.org',
+  additionalNtpSource: '0.rhel.pool.ntp.org',
 };
 
 export const getFacetLibVersion = () => packageJson.version;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -168,6 +168,7 @@ export const CLUSTER_DEFAULT_NETWORK_SETTINGS = {
   clusterNetworkCidr: '10.128.0.0/14',
   clusterNetworkHostPrefix: 23,
   serviceNetworkCidr: '172.30.0.0/16',
+  ntpSource: '0.rhel.pool.ntp.org',
 };
 
 export const getFacetLibVersion = () => packageJson.version;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -5,8 +5,9 @@ import {
   Host,
   Event,
   AddHostsClusterCreateParams,
+  HostValidationId,
 } from '../api/types';
-import { ValidationsInfo, Validation, HostRole } from '../types/hosts';
+import { ValidationsInfo, HostRole } from '../types/hosts';
 
 export let routeBasePath = '';
 export const setRouteBasePath = (basePath: string) => {
@@ -145,7 +146,7 @@ export const HOST_VALIDATION_GROUP_LABELS: { [key in keyof ValidationsInfo]: str
   role: 'Roles',
 };
 
-export const HOST_VALIDATION_LABELS: { [key in Validation['id']]: string } = {
+export const HOST_VALIDATION_LABELS: { [key in HostValidationId]: string } = {
   'has-inventory': 'Hardware information',
   'has-min-cpu-cores': 'Minimum CPU cores',
   'has-min-memory': 'Minimum Memory',
@@ -162,6 +163,26 @@ export const HOST_VALIDATION_LABELS: { [key in Validation['id']]: string } = {
   'belongs-to-majority-group': 'Belongs to majority connected group',
   'valid-platform': 'Platform',
   'ntp-synced': 'NTP synchronization',
+};
+
+export const HOST_VALIDATION_HINTS: { [key in HostValidationId]: string } = {
+  'has-inventory': '',
+  'has-min-cpu-cores': '',
+  'has-min-memory': '',
+  'has-min-valid-disks': '',
+  'has-cpu-cores-for-role': '',
+  'has-memory-for-role': '',
+  'hostname-unique': '',
+  'hostname-valid': '',
+  connected: '',
+  'machine-cidr-defined': '',
+  'belongs-to-machine-cidr': '',
+  'role-defined': '',
+  'api-vip-connected': '',
+  'belongs-to-majority-group': '',
+  'valid-platform': '',
+  'ntp-synced':
+    'Please manually fix hosts NTP configuration or provide Additional NTP source in Advanced networking configuration section.',
 };
 
 export const CLUSTER_DEFAULT_NETWORK_SETTINGS = {


### PR DESCRIPTION
- Add NTP source input field in advanced network configuration
- Add support for ntp-synced backend network validation
- Add NTP status to host detail

Depends on https://github.com/openshift/assisted-service/pull/675

Failing validation + NTP status unreachable:
![Screenshot from 2020-11-24 14-11-27](https://user-images.githubusercontent.com/1121740/100100237-c7472a00-2e60-11eb-8d29-b73e92a6d0ed.png)

Configuring NTP source:
![Screenshot from 2020-11-24 14-12-18](https://user-images.githubusercontent.com/1121740/100100252-d037fb80-2e60-11eb-9639-109300297186.png)

NTP synced:
![Screenshot from 2020-11-24 13-58-42](https://user-images.githubusercontent.com/1121740/100100276-db8b2700-2e60-11eb-90ab-e9908820f346.png)

