### PR TITLE
MGMT-1614 Report failed validation on host HW fields

### DIFF
--- a/src/components/hosts/HostPropertyValidationPopover.tsx
+++ b/src/components/hosts/HostPropertyValidationPopover.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { Button, ButtonVariant, Popover } from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationCircleIcon, PendingIcon } from '@patternfly/react-icons';
+import {
+  global_danger_color_100 as dangerColor,
+  global_success_color_100 as successColor,
+} from '@patternfly/react-tokens';
+import { Validation } from '../../types/hosts';
+import { HOST_VALIDATION_FAILURE_HINTS, HOST_VALIDATION_LABELS } from '../../config/constants';
+import { toSentence } from '../ui/table/utils';
+
+type ValidationPopoverProps = {
+  validation: Validation;
+};
+
+const ValidationPopover: React.FC<ValidationPopoverProps> = ({ validation, children }) => {
+  const failedValidationHint = HOST_VALIDATION_FAILURE_HINTS[validation.id];
+  return (
+    <Popover
+      headerContent={<div>{HOST_VALIDATION_LABELS[validation.id]}</div>}
+      bodyContent={
+        <div>
+          {toSentence(validation.message)}
+          {validation.status === 'failure' && failedValidationHint && ` ${failedValidationHint}`}
+        </div>
+      }
+    >
+      <Button variant={ButtonVariant.link} isInline>
+        {children}
+      </Button>
+    </Popover>
+  );
+};
+
+type HostPropertyValidationPopoverProps = {
+  validation?: Validation;
+  showFailure?: boolean;
+  showPending?: boolean;
+  showSuccess?: boolean;
+};
+
+const HostPropertyValidationPopover: React.FC<HostPropertyValidationPopoverProps> = ({
+  validation,
+  children,
+  showFailure = true,
+  showPending = false,
+  showSuccess = false,
+}) => {
+  if (validation) {
+    if (showFailure && validation.status === 'failure') {
+      return (
+        <ValidationPopover validation={validation}>
+          <ExclamationCircleIcon color={dangerColor.value} /> {children}
+        </ValidationPopover>
+      );
+    }
+    if (showPending && validation.status === 'pending') {
+      return (
+        <ValidationPopover validation={validation}>
+          <PendingIcon /> {children}
+        </ValidationPopover>
+      );
+    }
+    if (showSuccess && validation.status === 'success') {
+      return (
+        <ValidationPopover validation={validation}>
+          <CheckCircleIcon color={successColor.value} /> {children}
+        </ValidationPopover>
+      );
+    }
+  }
+  return <>{children}</>;
+};
+
+export default HostPropertyValidationPopover;

--- a/src/components/hosts/HostValidationGroups.tsx
+++ b/src/components/hosts/HostValidationGroups.tsx
@@ -8,7 +8,7 @@ import { PendingIcon, CheckCircleIcon, WarningTriangleIcon } from '@patternfly/r
 import { ValidationsInfo, Validation } from '../../types/hosts';
 import {
   HOST_VALIDATION_GROUP_LABELS,
-  HOST_VALIDATION_HINTS,
+  HOST_VALIDATION_FAILURE_HINTS,
   HOST_VALIDATION_LABELS,
 } from '../../config/constants';
 import { Cluster, Host } from '../../api';
@@ -68,7 +68,7 @@ const ValidationGroupAlert: React.FC<ValidationGroupAlertProps> = ({
         {validations.map((v) => (
           <li key={v.id}>
             <strong>{HOST_VALIDATION_LABELS[v.id] || v.id}:</strong>&nbsp;{toSentence(v.message)}{' '}
-            {v.status === 'failure' && HOST_VALIDATION_HINTS[v.id]}
+            {v.status === 'failure' && HOST_VALIDATION_FAILURE_HINTS[v.id]}
           </li>
         ))}
       </ul>

--- a/src/components/hosts/HostsTable.tsx
+++ b/src/components/hosts/HostsTable.tsx
@@ -58,9 +58,10 @@ import {
 import EditHostModal from './EditHostModal';
 import Hostname, { computeHostname } from './Hostname';
 import HostsCount from './HostsCount';
+import { ValidationsInfo } from '../../types/hosts';
+import HostPropertyValidationPopover from './HostPropertyValidationPopover';
 
 import './HostsTable.css';
-import { ValidationsInfo } from '../../types/hosts';
 
 type HostsTableProps = {
   cluster: Cluster;
@@ -96,6 +97,11 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
   const { cores, memory, disk } = getHostRowHardwareInfo(inventory);
   const computedHostname = computeHostname(host, inventory);
   const validationsInfo = stringToJSON<ValidationsInfo>(host.validationsInfo) || {};
+  const memoryValidation = validationsInfo?.hardware?.find((v) => v.id === 'has-memory-for-role');
+  const diskValidation = validationsInfo?.hardware?.find((v) => v.id === 'has-min-valid-disks');
+  const cpuCoresValidation = validationsInfo?.hardware?.find(
+    (v) => v.id === 'has-cpu-cores-for-role',
+  );
   return [
     {
       // visible row
@@ -118,9 +124,30 @@ const hostToHostTableRow = (openRows: OpenRows, cluster: Cluster) => (host: Host
           sortableValue: status,
         },
         getDateTimeCell(createdAt),
-        cores,
-        memory,
-        disk,
+        {
+          title: (
+            <HostPropertyValidationPopover validation={cpuCoresValidation}>
+              {cores.title}
+            </HostPropertyValidationPopover>
+          ),
+          sortableValue: cores.sortableValue,
+        },
+        {
+          title: (
+            <HostPropertyValidationPopover validation={memoryValidation}>
+              {memory.title}
+            </HostPropertyValidationPopover>
+          ),
+          sortableValue: memory.sortableValue,
+        },
+        {
+          title: (
+            <HostPropertyValidationPopover validation={diskValidation}>
+              {disk.title}
+            </HostPropertyValidationPopover>
+          ),
+          sortableValue: disk.sortableValue,
+        },
       ],
       host,
       clusterStatus: cluster.status,

--- a/src/components/hosts/NtpValidationStatus.tsx
+++ b/src/components/hosts/NtpValidationStatus.tsx
@@ -1,41 +1,26 @@
 import React from 'react';
-import { CheckCircleIcon, ExclamationCircleIcon, PendingIcon } from '@patternfly/react-icons';
-import {
-  global_danger_color_100 as dangerColor,
-  global_success_color_100 as successColor,
-} from '@patternfly/react-tokens';
-import { ValidationsInfo } from '../../types/hosts';
+import { Validation, ValidationsInfo } from '../../types/hosts';
+import HostPropertyValidationPopover from './HostPropertyValidationPopover';
+
+const getLabel = (validationStatus?: Validation['status']) => {
+  switch (validationStatus) {
+    case 'failure':
+      return 'Unreachable';
+    case 'success':
+      return 'Synced';
+    default:
+      return 'Pending';
+  }
+};
 
 const NtpValidationStatus: React.FC<{ validationsInfo: ValidationsInfo }> = ({
   validationsInfo,
 }) => {
   const ntpSyncedValidation = validationsInfo.network?.find((v) => v.id === 'ntp-synced');
-  switch (ntpSyncedValidation?.status) {
-    case 'success':
-      return (
-        <>
-          <CheckCircleIcon color={successColor.value} /> Synced
-        </>
-      );
-    case 'failure':
-      return (
-        <>
-          <ExclamationCircleIcon color={dangerColor.value} /> Unreachable (Configure NTP source in
-          Advanced networking section)
-        </>
-      );
-    case 'pending':
-      return (
-        <>
-          <PendingIcon /> Pending
-        </>
-      );
-    default:
-      return (
-        <>
-          <ExclamationCircleIcon color={dangerColor.value} /> Failed to validate NTP status
-        </>
-      );
-  }
+  return (
+    <HostPropertyValidationPopover validation={ntpSyncedValidation} showSuccess showPending>
+      {getLabel(ntpSyncedValidation?.status)}
+    </HostPropertyValidationPopover>
+  );
 };
 export default NtpValidationStatus;

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -151,8 +151,8 @@ export const HOST_VALIDATION_LABELS: { [key in HostValidationId]: string } = {
   'has-min-cpu-cores': 'Minimum CPU cores',
   'has-min-memory': 'Minimum Memory',
   'has-min-valid-disks': 'Minimum disks of required size',
-  'has-cpu-cores-for-role': 'Min. CPU cores required for selected role',
-  'has-memory-for-role': 'Min. memory required for selected role',
+  'has-cpu-cores-for-role': 'Minimum CPU cores for selected role',
+  'has-memory-for-role': 'Minimum memory for selected role',
   'hostname-unique': 'Unique hostname',
   'hostname-valid': 'Valid hostname',
   connected: 'Connected',
@@ -165,7 +165,7 @@ export const HOST_VALIDATION_LABELS: { [key in HostValidationId]: string } = {
   'ntp-synced': 'NTP synchronization',
 };
 
-export const HOST_VALIDATION_HINTS: { [key in HostValidationId]: string } = {
+export const HOST_VALIDATION_FAILURE_HINTS: { [key in HostValidationId]: string } = {
   'has-inventory': '',
   'has-min-cpu-cores': '',
   'has-min-memory': '',


### PR DESCRIPTION
Depends on: https://github.com/mareklibra/facet-lib/pull/327

- Introduces HostPropetyValidationPopover component which wraps host property in a Popover based on a validation status
- Adds validation popovers for host memory, cpu and disk properties
- Converts existing NtpValidationStatus to use HostPropertyValidationPopover

![Screenshot from 2020-11-27 12-41-53](https://user-images.githubusercontent.com/1121740/100445826-074f1c80-30ae-11eb-8931-c8677dc98d0c.png)
