### PR TITLE
Discovery ISO modal has stable ID

### DIFF
--- a/src/components/clusterConfiguration/discoveryImageModal.tsx
+++ b/src/components/clusterConfiguration/discoveryImageModal.tsx
@@ -50,6 +50,7 @@ const DiscoveryImageModal: React.FC<DiscoveryImageModalProps> = ({ closeModal, c
       onClose={closeModal}
       variant={ModalVariant.small}
       hasNoBodyWrapper
+      id="generate-discovery-iso-modal"
     >
       {imageInfo ? (
         <DiscoveryImageSummary


### PR DESCRIPTION
Use 'generate-discovery-iso-modal' instead of former 'pf-modal-part-XY'.