### PR TITLE
BZ 1905558: Handle missing openshift_version from OCM

### DIFF
--- a/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
+++ b/src/components/AddBareMetalHosts/BareMetalHostsClusterDetailTab.tsx
@@ -26,7 +26,9 @@ export const BareMetalHostsClusterDetailTab: React.FC<{
       setDay2Cluster(undefined);
     }
 
-    if (isVisible && day2Cluster === undefined && cluster && pullSecret) {
+    const openshiftClusterId = getOpenshiftClusterId(cluster);
+
+    if (isVisible && day2Cluster === undefined && cluster && openshiftClusterId && pullSecret) {
       // ensure exclusive run
       setDay2Cluster(null);
 
@@ -66,8 +68,6 @@ export const BareMetalHostsClusterDetailTab: React.FC<{
         setError('Missing API URL');
         return;
       }
-
-      const openshiftClusterId = getOpenshiftClusterId(cluster);
 
       const doItAsync = async () => {
         let dayTwoClusterExists = false;

--- a/src/components/AddBareMetalHosts/utils.ts
+++ b/src/components/AddBareMetalHosts/utils.ts
@@ -1,6 +1,7 @@
 import { OcmClusterType } from './types';
 
-export const getOpenshiftClusterId = (ocmCluster: OcmClusterType) => ocmCluster.external_id;
+export const getOpenshiftClusterId = (ocmCluster?: OcmClusterType) =>
+  ocmCluster && ocmCluster.external_id;
 
 export const canAddBareMetalHost = ({ cluster }: { cluster: OcmClusterType }) =>
   cluster.state === 'ready' &&

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -26,8 +26,8 @@ export const OPENSHIFT_VERSION_OPTIONS: OpenshiftVersionOptionType[] = [
 export const DEFAULT_OPENSHIFT_VERSION: OpenshiftVersionOptionType['value'] =
   OPENSHIFT_VERSION_OPTIONS[0].value;
 
-export const normalizeClusterVersion = (version: string) =>
-  OPENSHIFT_VERSIONS_ADDHOST.find((normalized) => version.startsWith(normalized));
+export const normalizeClusterVersion = (version?: string) =>
+  version && OPENSHIFT_VERSIONS_ADDHOST.find((normalized) => version.startsWith(normalized));
 
 export const CLUSTER_MANAGER_SITE_LINK = 'https://cloud.redhat.com/openshift/install/pull-secret';
 export const PULL_SECRET_INFO_LINK = CLUSTER_MANAGER_SITE_LINK;


### PR DESCRIPTION
Might happen during cluster upgrade.